### PR TITLE
HTTPS text-mode capture with HTTP/2 pairing

### DIFF
--- a/HTTPS_CAPTURE_TECHNICAL_HANDOFF.md
+++ b/HTTPS_CAPTURE_TECHNICAL_HANDOFF.md
@@ -1,0 +1,474 @@
+# HTTPS Capture - Technical Handoff & Completion Roadmap
+
+**Date:** January 12, 2026
+**Branch:** `feature/https-containerd-discovery`
+**Status:** Proof-of-concept working for OpenSSL only
+**Engineer:** Versilis Tyson
+
+---
+
+## Executive Summary
+
+This document provides a complete technical handoff for the HTTPS capture feature built on eCapture (eBPF-based SSL/TLS interception). The current implementation successfully captures HTTPS traffic from **Python services using OpenSSL**, but has critical limitations that prevent production deployment.
+
+**Key takeaway:** This is a partially working prototype. Completing this feature for production requires significant additional work (8-12 weeks estimate) and clear product requirements around language/framework support.
+
+---
+
+## Current State & Test Coverage
+
+### ✅ What's Confirmed Working
+
+- **Python + OpenSSL services** (tested with Front service in beta)
+  - SSL library discovery via filesystem scanning
+  - eCapture process launch in text mode
+  - HTTP/2 HEADERS and DATA frame parsing
+  - Request/response witness generation and backend ingestion
+  - Successfully captured outbound HTTPS API calls in minikube and beta
+
+- **Infrastructure**
+  - Multi-architecture Docker images (AMD64/ARM64)
+  - eCapture v0.8.6 bundled in agent image
+  - Kubernetes DaemonSet with required privileges (hostPID, privileged mode, eBPF capabilities)
+  - Containerd filesystem access for scanning container rootfs
+
+### ❌ What's Known Broken
+
+**See "Critical Blockers" section below for detailed breakdown.**
+
+---
+
+## Architecture Overview
+
+### High-Level Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Kubernetes Pod (Any Namespace)                                  │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  Application Process                                        │ │
+│  │  ├─ OpenSSL (libssl.so)  ← hooked by eCapture              │ │
+│  │  ├─ Go crypto/tls        ← NOT SUPPORTED YET               │ │
+│  │  └─ Java (javax.net.ssl) ← CANNOT BE SUPPORTED             │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+                           ↓
+┌─────────────────────────────────────────────────────────────────┐
+│  Postman Insights Agent (DaemonSet Pod on same node)            │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  1. Pod Event Listener (kube_events_worker.go)             │ │
+│  │     • Watches pod creation/deletion via Kubernetes API     │ │
+│  │     • Triggers SSL library scanning for new pods           │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                           ↓                                      │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  2. SSL Library Scanner (ssl_scanner.go)                   │ │
+│  │     • Reads container filesystem via containerd mount      │ │
+│  │     • Path: /run/containerd/.../rootfs/{containerID}       │ │
+│  │     • Searches for libssl.so in /lib, /usr/lib, etc.       │ │
+│  │     • Returns: LibraryPaths, LibraryType (openssl/go/etc)  │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                           ↓                                      │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  3. eCapture Manager (ecapture_manager.go)                 │ │
+│  │     • Launches: /ecapture tls --libssl=<path> -m text      │ │
+│  │     • One eCapture process per pod (keyed by containerID)  │ │
+│  │     • Captures stdout via pipe (NEVER writes to disk)      │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                           ↓                                      │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  4. Text Reader (ecapture_text_reader.go)                  │ │
+│  │     • Reads eCapture stdout line-by-line                   │ │
+│  │     • Buffers lines into logical frames                    │ │
+│  │     • Emits RawFrame structs via channel                   │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                           ↓                                      │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  5. Text Parser (text_parser.go)                           │ │
+│  │     • Detects protocol: HTTP/1.1 vs HTTP/2                 │ │
+│  │     • Parses HTTP/2 HEADERS frames → ParsedRequest         │ │
+│  │     • Parses HTTP/2 DATA frames → ParsedDataFrame          │ │
+│  │     • Parses HTTP/1.1 requests/responses                   │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                           ↓                                      │
+│  ┌────────────────────────────────────────────────────────────┐ │
+│  │  6. Text Collector (text_collector.go)                     │ │
+│  │     • Tracks HTTP/2 streams by stream ID                   │ │
+│  │     • Pairs requests with responses                        │ │
+│  │     • Converts to Witness (Postman's internal format)      │ │
+│  │     • Sends to backend ingestion pipeline                  │ │
+│  └────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Key File Structure
+
+```
+postman-insights-agent/
+├── cmd/internal/kube/daemonset/
+│   ├── daemonset.go              # Main entry point for DaemonSet mode
+│   ├── kube_events_worker.go     # Watches pod create/delete events
+│   ├── ssl_scanner.go            # Discovers SSL libraries in containers
+│   ├── ecapture_manager.go       # Manages eCapture subprocess lifecycle
+│   └── apidump_process.go        # Legacy pcap-based capture (still used for HTTP)
+│
+├── pcap/
+│   ├── ecapture_text_reader.go   # Buffers eCapture stdout into frames
+│   ├── text_parser.go            # Parses HTTP/1.1 and HTTP/2 text frames
+│   ├── text_collector.go         # Converts frames to witnesses
+│   ├── pcap.go                   # Legacy pcap-based capture
+│   └── stream.go                 # TCP stream reassembly (legacy)
+│
+└── Dockerfile / Makefile         # Build configuration
+
+observability-superstar-service/
+└── cli-postman/
+    ├── Dockerfile.cli.native     # Production image with eCapture binary
+    └── Makefile                  # Cross-compilation targets
+
+akita-infrastructure/
+└── modules/insights_agent_mns/
+    └── main.tf                   # Kubernetes DaemonSet definition
+```
+
+---
+
+## Critical Blockers (Must Fix for Production)
+
+### Blocker #1: Go TLS Not Supported (HIGH PRIORITY)
+
+**Impact:** Most backend services at Postman (kings-cross, timeline-builder, etc.) are written in Go.
+
+**Problem:**
+- Go uses `crypto/tls` package, which does NOT link against OpenSSL
+- Current SSL scanner only looks for OpenSSL libraries (`libssl.so`)
+- eCapture supports Go via `ecapture gotls` mode, but it's not implemented in our code
+
+**Current Code Issue (ssl_scanner.go:114-118):**
+```go
+if goExecutable := detectGoExecutable(rootfsPath); goExecutable != "" {
+    info.LibraryType = "go"
+    info.LibraryPaths = []string{goExecutable}  // BUG: Returns /usr/bin/go (compiler)
+}
+```
+This searches for the Go compiler (`/usr/bin/go`), not the actual application binary (e.g., `/app/kings-cross`).
+
+**What Needs to Happen:**
+1. Fix Go binary detection:
+   - Option A: Search `/proc/<pid>/exe` for all PIDs in container's cgroup
+   - Option B: Parse container metadata (ENTRYPOINT/CMD from image config)
+   - Option C: Search common app paths (`/app`, `/usr/local/bin`) for ELF binaries
+
+2. Add `gotls` mode to ecapture_manager.go:
+   ```go
+   if sslInfo.LibraryType == "go" {
+       cmd = exec.CommandContext(ctx, "/ecapture", "gotls",
+           "--elfpath="+sslInfo.LibraryPaths[0],  // Path to Go binary
+           "-m", "text",
+       )
+   }
+   ```
+
+3. Test with Go services (kings-cross in minikube, then beta)
+
+**Effort Estimate:** 3-4 weeks
+- 1 week: Research and implement Go binary detection
+- 1 week: Add gotls mode and integration testing
+- 1 week: Test in minikube with sample Go app
+- 0.5-1 week: Deploy to beta and verify with real services
+
+**Open Questions for Product:**
+- Which Go services are priority for HTTPS capture? (e.g., kings-cross, timeline-builder)
+- Do our Go binaries include debug symbols? (eCapture may require them)
+- Are we okay with higher overhead for Go capture? (gotls mode is less efficient than OpenSSL hooking)
+
+---
+
+### Blocker #2: Java and Other Languages Cannot Be Supported (FUNDAMENTAL LIMITATION)
+
+**Impact:** Services using Java, Ruby (with native TLS), or other languages that don't use OpenSSL or Go's crypto/tls.
+
+**Problem:**
+eCapture (and eBPF in general) works by hooking specific SSL library functions:
+- **Supported:** OpenSSL (`SSL_read`, `SSL_write`), BoringSSL, Go crypto/tls
+- **NOT Supported:** Java's `javax.net.ssl` (uses JVM-internal TLS implementation)
+
+**Why Java Doesn't Work:**
+- Java's TLS is implemented in the JVM itself, not via shared libraries
+- eBPF cannot hook into JVM internals (would require JVM instrumentation)
+- Even if we could hook the JVM, the data structures are completely different
+
+**Testing Status:**
+- ✅ **Tested and working:** Python (OpenSSL)
+- ✅ **Tested and confirmed broken:** Go (not implemented, but eCapture supports it)
+- ❌ **Not tested:** Node.js, Ruby, Rust, Java, .NET, PHP, Elixir
+
+**What Needs to Happen:**
+1. **Product decision required:** Create a language support matrix
+   - Which languages are in scope for HTTPS capture?
+   - What percentage of services use each language?
+   - What's our fallback for unsupported languages?
+
+2. **Testing plan for other languages:**
+   - Node.js: Should work (uses OpenSSL), but needs testing (~1 week)
+   - Ruby: Depends on Ruby version (may use OpenSSL or native TLS) (~1 week)
+   - Rust: Depends on TLS library (rustls vs openssl crate) (~1 week)
+   - Java: Won't work, need alternative approach (see below)
+
+3. **Alternative for Java (if needed):**
+   - Option A: Kernel-level SSL inspection (complex, requires mTLS handling)
+   - Option B: JVM agent instrumentation (separate project, 8+ weeks)
+   - Option C: Accept that Java HTTPS won't be captured
+
+**Effort Estimate:** 4-6 weeks (language testing only, excluding Java alternatives)
+
+**Critical Questions for Product:**
+- **What languages are in production at Postman?** Provide breakdown by service count.
+- **What's the priority order?** If we can only support 3 languages, which ones?
+- **What's the minimum viable language support?** Can we ship with just Python + Go?
+- **Is Java HTTPS capture a hard requirement?** If yes, this is a separate 3-month project.
+
+---
+
+### Blocker #3: HTTP/1.1 Pairing Not Implemented
+
+**Impact:** Services that make HTTP/1.1 HTTPS calls (not HTTP/2) won't generate full request/response witnesses.
+
+**Problem:**
+- Current text_collector.go only pairs HTTP/2 requests/responses (via stream IDs)
+- HTTP/1.1 doesn't have stream IDs, requires timing-based correlation
+- HTTP/1.1 parsing is implemented in text_parser.go but collector doesn't handle it
+
+**Symptoms:**
+- HTTP/1.1 requests parsed successfully
+- HTTP/1.1 responses parsed successfully
+- But they're never paired into a single witness
+
+**What Needs to Happen:**
+1. Implement HTTP/1.1 pairing logic in text_collector.go:
+   - Use timestamp + TCP connection (if available) to correlate
+   - Handle pipelined requests (multiple in-flight on same connection)
+   - Handle out-of-order responses (rare but possible)
+
+2. Test with HTTP/1.1 client (curl without `--http2` flag)
+
+**Effort Estimate:** 2-3 weeks
+- 1 week: Design and implement pairing logic
+- 1 week: Integration testing with various HTTP/1.1 scenarios
+- 0.5-1 week: Fix edge cases (pipelining, keep-alive, etc.)
+
+**Question for Product:**
+- What percentage of services use HTTP/1.1 vs HTTP/2 for outbound calls?
+- Can we ship with HTTP/2-only support initially?
+
+---
+
+### Blocker #4: SSL Library Discovery Flakiness
+
+**Impact:** Some OpenSSL-based pods aren't detected correctly.
+
+**Problem:**
+- ssl_scanner.go searches common paths (`/lib`, `/usr/lib`, etc.)
+- Doesn't handle all Linux distros (e.g., Alpine musl paths)
+- Doesn't handle symlinks correctly (e.g., `libssl.so` → `libssl.so.3.0.7`)
+- Doesn't retry on containerd mount timing issues
+
+**What Needs to Happen:**
+1. Expand search paths for Alpine, Debian, Ubuntu, RHEL variants
+2. Follow symlinks to find actual library files
+3. Add retry logic for containerd filesystem race conditions
+4. Log detailed debugging info when no libraries found
+
+**Effort Estimate:** 1-2 weeks
+
+---
+
+### Blocker #5: eCapture Process Stability
+
+**Impact:** eCapture processes crash or hang, requiring restart logic.
+
+**Current Status:**
+- Basic restart logic exists (ecapture_manager.go:monitorProcess)
+- But no health checks to detect hangs
+- No circuit breaker to prevent restart loops
+
+**What Needs to Happen:**
+1. Implement health check: Ensure eCapture outputs data periodically
+2. Add circuit breaker: Stop restarting after N failures
+3. Add telemetry: Track eCapture restart rate
+
+**Effort Estimate:** 1-2 weeks
+
+---
+
+## Timeline Estimates
+
+### Scenario 1: Minimum Viable Product (Python + Go only)
+**Goal:** Capture HTTPS from Python and Go services
+**Effort:** 6-8 weeks
+- Fix Go TLS support: 3-4 weeks
+- Fix HTTP/1.1 pairing: 2-3 weeks
+- Stabilization and testing: 1-2 weeks
+
+**Confidence:** Medium (depends on Go binary detection complexity)
+
+### Scenario 2: Production-Ready (Python, Go, Node.js)
+**Goal:** Support top 3 languages at Postman
+**Effort:** 10-12 weeks
+- Scenario 1 work: 6-8 weeks
+- Node.js testing and fixes: 1-2 weeks
+- SSL discovery improvements: 1-2 weeks
+- eCapture stability improvements: 1-2 weeks
+- Beta testing and bug fixes: 1-2 weeks
+
+**Confidence:** Medium-High
+
+### Scenario 3: Full Language Support (Excluding Java)
+**Goal:** Support all languages that use OpenSSL or Go crypto/tls
+**Effort:** 14-16 weeks
+- Scenario 2 work: 10-12 weeks
+- Ruby, Rust, PHP testing: 2-3 weeks
+- Edge case handling: 1-2 weeks
+
+**Confidence:** Low (many unknowns in language-specific behavior)
+
+### Scenario 4: Java Support (Separate Project)
+**Goal:** Add Java JVM instrumentation
+**Effort:** 12-16 weeks (separate from above)
+- Research JVM agent approach: 2 weeks
+- Implement JVM TLS hooks: 6-8 weeks
+- Integration with agent: 2-3 weeks
+- Testing and stabilization: 2-3 weeks
+
+**Confidence:** Very Low (unproven approach)
+
+---
+
+## Product Questions That Need Answers
+
+**Before continuing this work, product MUST provide:**
+
+1. **Language Priority Matrix**
+   - What languages are used in production? (by service count)
+   - Which languages are in scope for HTTPS capture?
+   - What's the priority order if we can't support all?
+
+2. **Definition of "Done"**
+   - What does "100% HTTPS capture" mean?
+   - Is it:
+     - A) Capture all HTTPS from any language?
+     - B) Capture HTTPS from specific priority services?
+     - C) Capture HTTPS from X% of services?
+   - What's the minimum acceptable coverage to ship this feature?
+
+3. **Java Requirements**
+   - How many production services use Java?
+   - Is Java HTTPS capture a hard requirement or nice-to-have?
+   - If required, are we committing to 3+ months of additional work?
+
+4. **Performance Expectations**
+   - What's the acceptable overhead per pod?
+   - Are we okay with higher overhead for Go services (gotls is slower)?
+   - Should we filter by namespace/labels to reduce overhead?
+
+5. **Failure Modes**
+   - What happens if we can't capture HTTPS from a pod?
+   - Silent fallback to HTTP-only? Or surface an error to users?
+
+6. **Security and Compliance**
+   - Are there any services where HTTPS capture is NOT allowed?
+   - Do we need opt-in/opt-out per service?
+   - How do we handle PII/secrets in decrypted traffic?
+
+---
+
+## Testing Checklist (Not Yet Done)
+
+Before deploying to production, the following MUST be tested:
+
+### Language Testing
+- [ ] Python + OpenSSL (various versions: 1.x, 3.x)
+- [ ] Go + crypto/tls (various Go versions: 1.18, 1.20, 1.21+)
+- [ ] Node.js + OpenSSL
+- [ ] Ruby (if in scope)
+- [ ] Rust (if in scope)
+- [ ] PHP (if in scope)
+- [ ] Java (confirm it fails gracefully)
+
+### Protocol Testing
+- [ ] HTTP/2 over TLS (currently working)
+- [ ] HTTP/1.1 over TLS (pairing not implemented)
+- [ ] gRPC over TLS (should work via HTTP/2, but not tested)
+- [ ] WebSockets over TLS (unknown)
+
+### Infrastructure Testing
+- [ ] Multi-node Kubernetes cluster (tested in beta, but flaky)
+- [ ] Pod restarts (does eCapture restart correctly?)
+- [ ] Agent restarts (does state recovery work?)
+- [ ] High-traffic pods (performance impact?)
+- [ ] Pods with no HTTPS traffic (silent failure?)
+
+### Edge Cases
+- [ ] Pods with multiple containers (which one to monitor?)
+- [ ] Init containers (should be ignored?)
+- [ ] Sidecar containers (e.g., Envoy proxies)
+- [ ] Pods with custom base images (Alpine, distroless, etc.)
+- [ ] Pods with no SSL libraries (graceful failure?)
+
+---
+
+## Known Issues (Unfixable or Low Priority)
+
+### Issue: Incoming HTTPS Traffic Not Captured
+**Why:** ALB/Ingress terminates TLS before traffic reaches pods
+**Impact:** We can only capture outbound HTTPS calls, not incoming requests
+**Status:** This is expected behavior, not a bug
+
+### Issue: Architecture Mismatch (RESOLVED)
+**Why:** Built ARM64 image on Mac, beta cluster runs AMD64
+**Fix:** Multi-architecture Dockerfile now builds both AMD64 and ARM64
+**Status:** Fixed in commit 138dcdd
+
+---
+
+## References
+
+### Related PRs and Branches
+- **postman-insights-agent:** `feature/https-containerd-discovery` (current branch)
+- **observability-superstar-service:** `versilis/https-capture-rc`
+- **akita-infrastructure:** `versilis/https-capture`
+
+### External Documentation
+- eCapture GitHub: https://github.com/gojue/ecapture
+- eCapture Go TLS support: https://medium.com/@cfc4ncs/ecapture-supports-capturing-plaintext-of-golang-tls-https-traffic-f16874048269
+- eBPF programming guide: https://ebpf.io/
+
+### Key Commits
+- `138dcdd` - Initial eCapture integration (text mode)
+- `729356a` - Fixed security context for eBPF
+- `469dc53` - Fixed container skip bug
+- `727aa9a` - Added eCapture retry and stderr logging
+- `bb4010f` - WIP (current HEAD)
+
+---
+
+## Contact and Handoff Notes
+
+**Original Engineer:** Versilis Tyson (leaving company)
+**Status:** This is a working prototype for OpenSSL-based Python services only. **Do not deploy to production without addressing the blockers above.**
+
+**Next Steps for Whoever Picks This Up:**
+1. Read this document thoroughly
+2. Schedule a meeting with product to answer the "Product Questions" section
+3. Based on product priorities, start with either:
+   - **Scenario 1** (MVP: Python + Go) if you need something fast
+   - **Scenario 2** (Production-ready) if you have 3 months
+4. Set up a test environment with Go and Python services in minikube
+5. Read the code in this order:
+   - `cmd/internal/kube/daemonset/kube_events_worker.go` (entry point)
+   - `cmd/internal/kube/daemonset/ssl_scanner.go` (start here for Go TLS fix)
+   - `cmd/internal/kube/daemonset/ecapture_manager.go` (add gotls mode here)
+   - `pcap/text_parser.go` (understand frame parsing)
+   - `pcap/text_collector.go` (implement HTTP/1.1 pairing here)
+
+**Good luck. This is hard but cool work.**

--- a/HTTPS_CAPTURE_TECHNICAL_HANDOFF.md
+++ b/HTTPS_CAPTURE_TECHNICAL_HANDOFF.md
@@ -448,7 +448,7 @@ Before deploying to production, the following MUST be tested:
 - `729356a` - Fixed security context for eBPF
 - `469dc53` - Fixed container skip bug
 - `727aa9a` - Added eCapture retry and stderr logging
-- `bb4010f` - WIP (current HEAD)
+- `edc787e` - WIP + technical handoff document (current HEAD)
 
 ---
 

--- a/build-scripts/Dockerfile
+++ b/build-scripts/Dockerfile
@@ -35,8 +35,26 @@ COPY ../ ./
 RUN go build -tags osusergo,netgo -ldflags "-linkmode external -extldflags '-static'" -o /out/postman-insights-agent .
 
 #
-# Step 2: Copy the binary to an empty Alpine image to export to local machine.
+# Step 1.5: Download eCapture binary for HTTPS traffic capture
 #
-FROM scratch AS bin
+FROM alpine:latest AS ecapture-download
+RUN apk add --no-cache wget tar
+# Download eCapture release (adjust version and architecture as needed)
+RUN wget -O /tmp/ecapture.tar.gz https://github.com/gojue/ecapture/releases/download/v0.8.6/ecapture-v0.8.6-linux-arm64.tar.gz && \
+    tar -xzf /tmp/ecapture.tar.gz -C /tmp && \
+    mv /tmp/ecapture-v0.8.6-linux-arm64/ecapture /tmp/ecapture && \
+    chmod +x /tmp/ecapture
+
+#
+# Step 2: Copy both binaries to Alpine image (needed for eCapture runtime dependencies)
+#
+FROM alpine:latest AS bin
+
+# Install runtime dependencies for eCapture
+RUN apk add --no-cache ca-certificates
 
 COPY --from=build /out/postman-insights-agent /postman-insights-agent
+COPY --from=ecapture-download /tmp/ecapture /ecapture
+
+# Ensure eCapture is executable
+RUN chmod +x /ecapture

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -44,6 +44,9 @@ type Daemonset struct {
 	CRIClient   *cri_apis.CriClient
 	FrontClient rest.FrontClient
 
+	// eCapture manager for HTTPS traffic capture
+	EcaptureManager *EcaptureManager
+
 	// Note: Only filtered pods are stored in this map, i.e., they have required env vars
 	// and do not have the agent sidecar container
 	PodArgsByNameMap sync.Map
@@ -115,6 +118,7 @@ func StartDaemonset(args DaemonsetArgs) error {
 		KubeClient:               kubeClient,
 		CRIClient:                criClient,
 		FrontClient:              frontClient,
+		EcaptureManager:          NewEcaptureManager(),
 		TelemetryInterval:        telemetryInterval,
 		PodHealthCheckInterval:   DefaultPodHealthCheckInterval,
 	}
@@ -178,6 +182,10 @@ func (d *Daemonset) Run() error {
 	// Stop all apidump processes
 	printer.Debugf("Stopping all apidump processes...\n")
 	d.StopAllApiDumpProcesses()
+
+	// Stop all eCapture processes
+	printer.Debugf("Stopping all eCapture processes...\n")
+	d.EcaptureManager.Shutdown()
 
 	// Stop K8s Watcher
 	printer.Debugf("Stopping k8s watcher...\n")
@@ -276,6 +284,17 @@ func (d *Daemonset) StartProcessInExistingPods() error {
 		if err != nil {
 			printer.Errorf("Failed to add pod args to map, pod name: %s, error: %v\n", pod.Name, err)
 			continue
+		}
+
+		// Start eCapture for HTTPS traffic if SSL libraries were found
+		if args.SSLLibInfo != nil {
+			httpsFile, err := d.EcaptureManager.StartCapture(args.ContainerUUID, args.PodName, args.SSLLibInfo)
+			if err != nil {
+				printer.Warningf("Failed to start eCapture for pod %s: %v\n", args.PodName, err)
+				printer.Warningf("HTTPS traffic will not be captured for this pod\n")
+			} else {
+				printer.Infof("DEBUG: HTTPS capture started for pod %s: %s\n", args.PodName, httpsFile)
+			}
 		}
 
 		err = d.StartApiDumpProcess(pod.UID)

--- a/cmd/internal/kube/daemonset/ecapture_manager.go
+++ b/cmd/internal/kube/daemonset/ecapture_manager.go
@@ -1,0 +1,216 @@
+package daemonset
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/pcap"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// EcaptureProcess represents a running eCapture process for a specific pod
+type EcaptureProcess struct {
+	ContainerID string
+	PodName     string
+	TextReader  *pcap.EcaptureTextReader // Reader for text mode output
+	Cmd         *exec.Cmd
+	Ctx         context.Context
+	Cancel      context.CancelFunc
+	mu          sync.Mutex
+}
+
+// EcaptureManager manages eCapture processes for multiple pods
+type EcaptureManager struct {
+	processes map[string]*EcaptureProcess // keyed by containerID
+	mu        sync.RWMutex
+}
+
+// NewEcaptureManager creates a new eCapture manager
+func NewEcaptureManager() *EcaptureManager {
+	return &EcaptureManager{
+		processes: make(map[string]*EcaptureProcess),
+	}
+}
+
+// StartCapture starts an eCapture process for a pod with the given SSL library info
+// Returns the container ID (used as identifier to retrieve frame channel later)
+func (m *EcaptureManager) StartCapture(containerID, podName string, sslInfo *SSLLibraryInfo) (string, error) {
+	if sslInfo == nil || len(sslInfo.LibraryPaths) == 0 {
+		return "", fmt.Errorf("no SSL library information available for pod %s", podName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if already running
+	if _, exists := m.processes[containerID]; exists {
+		printer.Debugf("eCapture already running for container %s (pod: %s)\n", containerID, podName)
+		return containerID, nil
+	}
+
+	// Select the first SSL library path (or implement smarter selection logic)
+	libPath := sslInfo.LibraryPaths[0]
+
+	// Create context for cancellation
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Build eCapture command in TEXT mode (outputs decrypted plaintext to stdout)
+	// eCapture command format: ecapture tls --libssl=<path> -m text
+	cmd := exec.CommandContext(ctx, "/ecapture", "tls",
+		"--libssl="+libPath,
+		"-m", "text",
+	)
+
+	printer.Infof("🔥 DEBUG: Starting eCapture in TEXT mode for pod %s\n", podName)
+	printer.Infof("🔥 DEBUG: Container: %s\n", containerID)
+	printer.Infof("🔥 DEBUG: SSL library: %s\n", libPath)
+	printer.Infof("🔥 DEBUG: Command: %v\n", cmd.Args)
+
+	// Capture stdout with pipe (NEVER write plaintext to disk)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return "", fmt.Errorf("failed to create stdout pipe for pod %s: %w", podName, err)
+	}
+
+	// Redirect stderr to agent logs for debugging
+	cmd.Stderr = os.Stderr
+
+	// Start the process BEFORE creating reader (pipe must be ready)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return "", fmt.Errorf("failed to start eCapture for pod %s: %w", podName, err)
+	}
+
+	// Create text reader to process stdout
+	textReader := pcap.NewEcaptureTextReader(stdout, podName)
+	textReader.Start()
+
+	// Store process info
+	proc := &EcaptureProcess{
+		ContainerID: containerID,
+		PodName:     podName,
+		TextReader:  textReader,
+		Cmd:         cmd,
+		Ctx:         ctx,
+		Cancel:      cancel,
+	}
+	m.processes[containerID] = proc
+
+	// Monitor process in goroutine
+	go m.monitorProcess(proc)
+
+	printer.Infof("eCapture TEXT mode started for pod %s (PID: %d)\n", podName, cmd.Process.Pid)
+	printer.Debugf("eCapture will output decrypted HTTP/HTTPS traffic to in-memory channel\n")
+
+	// Return container ID as identifier (used to retrieve frame channel later)
+	return containerID, nil
+}
+
+// StopCapture stops the eCapture process for a given container
+func (m *EcaptureManager) StopCapture(containerID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	proc, exists := m.processes[containerID]
+	if !exists {
+		return fmt.Errorf("no eCapture process found for container %s", containerID)
+	}
+
+	proc.mu.Lock()
+	defer proc.mu.Unlock()
+
+	printer.Infof("Stopping eCapture for pod %s (container: %s)\n", proc.PodName, containerID)
+
+	// Stop the text reader first
+	if proc.TextReader != nil {
+		proc.TextReader.Stop()
+	}
+
+	// Cancel the context to signal shutdown
+	proc.Cancel()
+
+	// Wait for process to exit (with timeout)
+	done := make(chan error, 1)
+	go func() {
+		done <- proc.Cmd.Wait()
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		// Force kill if graceful shutdown takes too long
+		if proc.Cmd.Process != nil {
+			proc.Cmd.Process.Kill()
+		}
+		printer.Warningf("eCapture process for pod %s did not exit gracefully, killed\n", proc.PodName)
+	case err := <-done:
+		if err != nil && err.Error() != "signal: killed" && err.Error() != "context canceled" {
+			printer.Debugf("eCapture process for pod %s exited with error: %v\n", proc.PodName, err)
+		}
+	}
+
+	delete(m.processes, containerID)
+	return nil
+}
+
+// GetFrameChannel returns the frame channel for a given container's eCapture process
+func (m *EcaptureManager) GetFrameChannel(containerID string) (<-chan pcap.RawFrame, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	proc, exists := m.processes[containerID]
+	if !exists {
+		return nil, fmt.Errorf("no eCapture process found for container %s", containerID)
+	}
+
+	if proc.TextReader == nil {
+		return nil, fmt.Errorf("text reader not initialized for container %s", containerID)
+	}
+
+	return proc.TextReader.FrameChannel(), nil
+}
+
+// monitorProcess monitors an eCapture process and handles unexpected exits
+func (m *EcaptureManager) monitorProcess(proc *EcaptureProcess) {
+	err := proc.Cmd.Wait()
+
+	// Check if this was an expected shutdown (context canceled)
+	select {
+	case <-proc.Ctx.Done():
+		printer.Debugf("eCapture process for pod %s exited normally\n", proc.PodName)
+		return
+	default:
+		// Unexpected exit
+		if err != nil {
+			printer.Errorf("eCapture process for pod %s exited unexpectedly: %v\n", proc.PodName, err)
+		} else {
+			printer.Warningf("eCapture process for pod %s exited unexpectedly without error\n", proc.PodName)
+		}
+
+		// Remove from map
+		m.mu.Lock()
+		delete(m.processes, proc.ContainerID)
+		m.mu.Unlock()
+	}
+}
+
+// Shutdown stops all running eCapture processes
+func (m *EcaptureManager) Shutdown() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	printer.Infof("Shutting down eCapture manager, stopping %d processes\n", len(m.processes))
+
+	for containerID := range m.processes {
+		// Unlock for StopCapture call (which locks internally)
+		m.mu.Unlock()
+		if err := m.StopCapture(containerID); err != nil {
+			printer.Errorf("Error stopping eCapture for container %s: %v\n", containerID, err)
+		}
+		m.mu.Lock()
+	}
+}

--- a/cmd/internal/kube/daemonset/pod_args.go
+++ b/cmd/internal/kube/daemonset/pod_args.go
@@ -54,6 +54,7 @@ type PodArgs struct {
 	PodName       string
 	ContainerUUID string
 	PodCreds      PodCreds
+	SSLLibInfo    *SSLLibraryInfo // SSL library information for HTTPS capture
 
 	// for state management
 	PodTrafficMonitorState PodTrafficMonitorState

--- a/cmd/internal/kube/daemonset/ssl_scanner.go
+++ b/cmd/internal/kube/daemonset/ssl_scanner.go
@@ -1,0 +1,202 @@
+package daemonset
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// SSLLibraryInfo contains information about discovered SSL libraries in a container
+type SSLLibraryInfo struct {
+	ContainerID  string
+	LibraryPaths []string
+	LibraryType  string // "openssl", "boringssl", "gnutls", "go", "node", "java"
+}
+
+// ScanContainerSSLLibraries scans a container's filesystem (via containerd) for SSL libraries.
+// Returns information about discovered libraries that eCapture can hook.
+//
+// For containerd, the container's root filesystem is mounted at:
+// /run/containerd/io.containerd.runtime.v2.task/k8s.io/{containerID}/rootfs
+//
+// This function searches common library paths within that rootfs:
+// - /lib, /lib64, /usr/lib, /usr/lib64 (Debian/Ubuntu/RHEL)
+// - /lib, /usr/lib (Alpine/musl)
+// - /usr/local/lib (custom builds)
+func ScanContainerSSLLibraries(containerID string) (*SSLLibraryInfo, error) {
+	if containerID == "" {
+		return nil, fmt.Errorf("container ID cannot be empty")
+	}
+
+	// Path to container's root filesystem via containerd
+	rootfsPath := fmt.Sprintf("/run/containerd/io.containerd.runtime.v2.task/k8s.io/%s/rootfs", containerID)
+
+	// Check if rootfs exists
+	if _, err := os.Stat(rootfsPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("container rootfs not found at %s", rootfsPath)
+	}
+
+	info := &SSLLibraryInfo{
+		ContainerID:  containerID,
+		LibraryPaths: []string{},
+	}
+
+	// Common library search paths (relative to rootfs)
+	searchPaths := []string{
+		"lib",
+		"lib64",
+		"usr/lib",
+		"usr/lib64",
+		"usr/local/lib",
+		"lib/x86_64-linux-gnu",     // Debian/Ubuntu x86_64
+		"lib/aarch64-linux-gnu",    // Debian/Ubuntu ARM64
+		"usr/lib/x86_64-linux-gnu", // Debian/Ubuntu x86_64
+		"usr/lib/aarch64-linux-gnu", // Debian/Ubuntu ARM64
+	}
+
+	// Search for SSL libraries
+	for _, searchPath := range searchPaths {
+		fullPath := filepath.Join(rootfsPath, searchPath)
+
+		// Skip if path doesn't exist
+		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
+			continue
+		}
+
+		// Walk the directory looking for SSL libraries
+		err := filepath.Walk(fullPath, func(path string, fileInfo os.FileInfo, err error) error {
+			if err != nil {
+				return nil // Skip errors, continue scanning
+			}
+
+			// Skip directories
+			if fileInfo.IsDir() {
+				return nil
+			}
+
+			filename := filepath.Base(path)
+
+			// Match SSL library patterns
+			// - libssl.so, libssl.so.1, libssl.so.1.1, libssl.so.3
+			// Note: Only match libssl, not libcrypto (libcrypto doesn't have SSL_write/SSL_read symbols)
+			if strings.Contains(filename, "libssl.so") {
+
+				// Prefer versioned libraries (more specific)
+				// e.g., libssl.so.3 over libssl.so
+				if strings.Count(filename, ".") >= 2 {
+					info.LibraryPaths = append(info.LibraryPaths, path)
+
+					// Detect library type from version
+					if strings.Contains(filename, "libssl.so.3") {
+						info.LibraryType = "openssl-3.x"
+					} else if strings.Contains(filename, "libssl.so.1.1") {
+						info.LibraryType = "openssl-1.1.x"
+					} else if strings.Contains(filename, "libssl.so.1.0") {
+						info.LibraryType = "openssl-1.0.x"
+					}
+				}
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			printer.Debugf("Error scanning %s: %v\n", fullPath, err)
+		}
+	}
+
+	// If no libraries found, check for special cases
+	if len(info.LibraryPaths) == 0 {
+		// Check for Go binaries (no libssl needed, uses crypto/tls)
+		if goExecutable := detectGoExecutable(rootfsPath); goExecutable != "" {
+			info.LibraryType = "go"
+			info.LibraryPaths = []string{goExecutable}
+			printer.Debugf("Detected Go application in container %s\n", containerID)
+		}
+
+		// Check for Node.js (statically linked SSL)
+		if nodeExecutable := detectNodeExecutable(rootfsPath); nodeExecutable != "" {
+			info.LibraryType = "node"
+			info.LibraryPaths = []string{nodeExecutable}
+			printer.Debugf("Detected Node.js application in container %s\n", containerID)
+		}
+
+		// Check for Java (uses custom SSL, not supported by eCapture)
+		if javaExecutable := detectJavaExecutable(rootfsPath); javaExecutable != "" {
+			info.LibraryType = "java"
+			printer.Debugf("Detected Java application in container %s (HTTPS capture not supported)\n", containerID)
+			return info, fmt.Errorf("Java applications use custom SSL implementation, not supported by eCapture")
+		}
+	}
+
+	if len(info.LibraryPaths) == 0 && info.LibraryType == "" {
+		return nil, fmt.Errorf("no SSL libraries found in container %s", containerID)
+	}
+
+	printer.Debugf("Found %d SSL library paths in container %s (type: %s)\n",
+		len(info.LibraryPaths), containerID, info.LibraryType)
+
+	return info, nil
+}
+
+// detectGoExecutable checks if the container has a Go binary
+// Go binaries typically use crypto/tls (no shared libssl)
+func detectGoExecutable(rootfsPath string) string {
+	// Check common Go binary locations
+	goBinaries := []string{
+		"usr/local/bin/go",
+		"usr/bin/go",
+	}
+
+	for _, binPath := range goBinaries {
+		fullPath := filepath.Join(rootfsPath, binPath)
+		if _, err := os.Stat(fullPath); err == nil {
+			return fullPath
+		}
+	}
+
+	return ""
+}
+
+// detectNodeExecutable checks if the container has Node.js
+// Node.js statically links SSL, so we target the node binary itself
+func detectNodeExecutable(rootfsPath string) string {
+	// Check common Node.js binary locations
+	nodeBinaries := []string{
+		"usr/local/bin/node",
+		"usr/bin/node",
+		"bin/node",
+	}
+
+	for _, binPath := range nodeBinaries {
+		fullPath := filepath.Join(rootfsPath, binPath)
+		if _, err := os.Stat(fullPath); err == nil {
+			return fullPath
+		}
+	}
+
+	return ""
+}
+
+// detectJavaExecutable checks if the container has Java
+// Java uses custom SSL (javax.net.ssl), not supported by eCapture
+func detectJavaExecutable(rootfsPath string) string {
+	// Check common Java binary locations
+	javaBinaries := []string{
+		"usr/local/openjdk*/bin/java",
+		"usr/bin/java",
+		"bin/java",
+	}
+
+	for _, binPattern := range javaBinaries {
+		matches, _ := filepath.Glob(filepath.Join(rootfsPath, binPattern))
+		if len(matches) > 0 {
+			return matches[0]
+		}
+	}
+
+	return ""
+}

--- a/k8s/demo-https-service-beta.yaml
+++ b/k8s/demo-https-service-beta.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: https-demo
+  namespace: postman-insights-namespace
+  labels:
+    app: https-demo
+spec:
+  restartPolicy: Always
+  containers:
+    - name: traffic-generator
+      # Use curl-based generator (same approach as test-https-app)
+      image: curlimages/curl:latest
+      command: ["/bin/sh", "-c"]
+      # env:
+      #   - name: POSTMAN_INSIGHTS_API_KEY
+      #     value: "YOUR_API_KEY_HERE"
+      #   - name: POSTMAN_INSIGHTS_PROJECT_ID
+      #     value: "YOUR_PROJECT_ID_HERE"
+      args:
+        - |
+          set -e
+          echo "cURL version:"
+          curl --version
+          echo "=== Realistic HTTPS Traffic Generator (curl) ==="
+          while true; do
+            echo "[$(date '+%H:%M:%S')] === Batch 1: User Management ==="
+            curl -s https://jsonplaceholder.typicode.com/users -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/users/1 -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/users/2/posts -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/users/3/albums -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/users/4/todos -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] === Batch 2: Posts & Comments ==="
+            curl -s https://jsonplaceholder.typicode.com/posts -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/posts/1 -o /dev/null
+            curl -s https://jsonplaceholder.typicode.com/posts/1/comments -o /dev/null
+            curl -s "https://jsonplaceholder.typicode.com/comments?postId=1" -o /dev/null
+            curl -s -X POST https://jsonplaceholder.typicode.com/posts -H "Content-Type: application/json" -d '{"title":"test","body":"demo","userId":1}' -o /dev/null
+            curl -s -X PUT https://jsonplaceholder.typicode.com/posts/1 -H "Content-Type: application/json" -d '{"id":1,"title":"updated"}' -o /dev/null
+            curl -s -X DELETE https://jsonplaceholder.typicode.com/posts/1 -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] === Batch 3: HTTPBin (Testing Service) ==="
+            curl -s https://httpbin.org/uuid -o /dev/null
+            curl -s https://httpbin.org/ip -o /dev/null
+            curl -s https://httpbin.org/user-agent -o /dev/null
+            curl -s https://httpbin.org/headers -o /dev/null
+            curl -s https://httpbin.org/delay/1 -o /dev/null
+            curl -s https://httpbin.org/status/200 -o /dev/null
+            curl -s https://httpbin.org/status/404 -o /dev/null
+            curl -s -X POST https://httpbin.org/post -H "Content-Type: application/json" -d '{"key":"value"}' -o /dev/null
+            curl -s -X PUT https://httpbin.org/put -H "Content-Type: application/json" -d '{"update":"data"}' -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] === Batch 4: GitHub API ==="
+            curl -s https://api.github.com/zen -o /dev/null
+            curl -s https://api.github.com/users/github -o /dev/null
+            curl -s https://api.github.com/users/github/repos -o /dev/null
+            curl -s https://api.github.com/repos/github/docs -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] === Batch 5: ReqRes API ==="
+            curl -s https://reqres.in/api/users -o /dev/null
+            curl -s https://reqres.in/api/users/1 -o /dev/null
+            curl -s "https://reqres.in/api/users?page=2" -o /dev/null
+            curl -s -X POST https://reqres.in/api/users -H "Content-Type: application/json" -d '{"name":"test","job":"developer"}' -o /dev/null
+            curl -s -X PUT https://reqres.in/api/users/2 -H "Content-Type: application/json" -d '{"name":"updated"}' -o /dev/null
+            curl -s -X DELETE https://reqres.in/api/users/2 -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] === Batch 6: Cat Facts (Fun API) ==="
+            curl -s https://catfact.ninja/fact -o /dev/null
+            curl -s https://catfact.ninja/facts -o /dev/null
+            curl -s https://catfact.ninja/breeds -o /dev/null
+
+            echo "[$(date '+%H:%M:%S')] Completed 35 HTTPS requests. Waiting 15 seconds..."
+            sleep 15
+          done
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "200m"
+          memory: "256Mi"

--- a/k8s/postman-insights-agent-daemonset.yaml
+++ b/k8s/postman-insights-agent-daemonset.yaml
@@ -79,7 +79,19 @@ spec:
               cpu: 200m
               memory: 500Mi
           securityContext:
-            privileged: true
+            capabilities:
+              add:
+                # Agent pcap/tracing capabilities
+                - SYS_ADMIN  # Fallback for kernels < 5.8
+                - SYS_PTRACE # Container tracing
+                - NET_RAW    # Packet capture
+                # Embedded eCapture (eBPF) dependencies
+                - SYS_RESOURCE # eBPF memory/resource operations
+                - NET_ADMIN    # eBPF network program attachment
+                - BPF          # Load eBPF programs and create maps
+                - PERFMON      # Performance monitoring/tracing hooks
+              drop:
+                - ALL
           volumeMounts:
             - mountPath: /host/proc
               name: host-procfs

--- a/k8s/postman-insights-agent-daemonset.yaml
+++ b/k8s/postman-insights-agent-daemonset.yaml
@@ -1,0 +1,119 @@
+# Create namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postman-insights-namespace
+---
+# Create service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: postman-insights-service-account
+  namespace: postman-insights-namespace
+automountServiceAccountToken: false
+---
+# Create role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: postman-insights-read-only-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+---
+# Give viewer access to the service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: postman-insights-view-all-resources-binding
+subjects:
+  - kind: ServiceAccount
+    name: postman-insights-service-account
+    namespace: postman-insights-namespace
+roleRef:
+  kind: ClusterRole
+  name: postman-insights-read-only-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# Create daemonset for running agent
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: postman-insights-agent
+  namespace: postman-insights-namespace
+spec:
+  selector:
+    matchLabels:
+      name: postman-insights-agent
+  template:
+    metadata:
+      labels:
+        name: postman-insights-agent
+    spec:
+      serviceAccountName: postman-insights-service-account
+      automountServiceAccountToken: true
+      hostPID: true # Required for eCapture to access all process PIDs
+      containers:
+        - command:
+            - /postman-insights-agent
+          args:
+            - kube
+            - run
+            - --repro-mode
+          env:
+            - name: POSTMAN_INSIGHTS_K8S_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POSTMAN_INSIGHTS_CRI_ENDPOINT
+              value: /var/run/containerd/containerd.sock
+          image: postman-insights-agent:https-ingestion
+          imagePullPolicy: Never
+          name: postman-insights-agent
+          resources:
+            requests:
+              cpu: 200m
+              memory: 500Mi
+            limits:
+              cpu: 200m
+              memory: 500Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /host/proc
+              name: host-procfs
+              readOnly: true
+            - mountPath: /host/var/run/netns
+              mountPropagation: HostToContainer
+              name: host-netns
+              readOnly: true
+            - mountPath: /var/run/containerd/containerd.sock
+              name: containerdsocket
+              readOnly: true
+            - mountPath: /run/containerd
+              name: containerd-runtime
+              readOnly: true
+      restartPolicy: Always
+      volumes:
+        - name: host-procfs
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: host-netns
+          hostPath:
+            path: /var/run/netns
+            type: Directory
+        - name: containerdsocket
+          hostPath:
+            path: /var/run/containerd/containerd.sock
+            type: Socket
+        # Containerd runtime directory for accessing container filesystems
+        - name: containerd-runtime
+          hostPath:
+            path: /run/containerd
+            type: Directory
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 30%

--- a/k8s/postman-insights-agent-daemonset.yaml
+++ b/k8s/postman-insights-agent-daemonset.yaml
@@ -68,8 +68,8 @@ spec:
                   fieldPath: spec.nodeName
             - name: POSTMAN_INSIGHTS_CRI_ENDPOINT
               value: /var/run/containerd/containerd.sock
-          image: postman-insights-agent:https-ingestion
-          imagePullPolicy: Never
+          image: postman-insights-agent-release:latest
+          imagePullPolicy: IfNotPresent
           name: postman-insights-agent
           resources:
             requests:
@@ -82,14 +82,14 @@ spec:
             capabilities:
               add:
                 # Agent pcap/tracing capabilities
-                - SYS_ADMIN  # Fallback for kernels < 5.8
+                - SYS_ADMIN # Fallback for kernels < 5.8
                 - SYS_PTRACE # Container tracing
-                - NET_RAW    # Packet capture
+                - NET_RAW # Packet capture
                 # Embedded eCapture (eBPF) dependencies
                 - SYS_RESOURCE # eBPF memory/resource operations
-                - NET_ADMIN    # eBPF network program attachment
-                - BPF          # Load eBPF programs and create maps
-                - PERFMON      # Performance monitoring/tracing hooks
+                - NET_ADMIN # eBPF network program attachment
+                - BPF # Load eBPF programs and create maps
+                - PERFMON # Performance monitoring/tracing hooks
               drop:
                 - ALL
           volumeMounts:

--- a/k8s/test-https-app.yaml
+++ b/k8s/test-https-app.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-https-app
+  namespace: postman-insights-namespace
+spec:
+  containers:
+    - name: curl-loop
+      image: curlimages/curl:latest
+      command: ["/bin/sh"]
+      args:
+        - -c
+        - |
+          echo "Starting HTTPS request loop..."
+          while true; do
+            echo "Sending request to GitHub API..."
+            curl -s https://api.github.com/zen
+            echo ""
+            echo "Sending request to Google..."
+            curl -s https://www.google.com/ | head -c 100
+            echo ""
+            echo "Waiting 10 seconds..."
+            sleep 10
+          done
+      env:
+        - name: POSTMAN_INSIGHTS_API_KEY
+          value: "YOUR_API_KEY_HERE"
+        - name: POSTMAN_INSIGHTS_PROJECT_ID
+          value: "YOUR_PROJECT_ID_HERE"

--- a/k8s/test-https-app.yaml
+++ b/k8s/test-https-app.yaml
@@ -22,8 +22,8 @@ spec:
             echo "Waiting 10 seconds..."
             sleep 10
           done
-      env:
-        - name: POSTMAN_INSIGHTS_API_KEY
-          value: "YOUR_API_KEY_HERE"
-        - name: POSTMAN_INSIGHTS_PROJECT_ID
-          value: "YOUR_PROJECT_ID_HERE"
+      # env:
+      #   - name: POSTMAN_INSIGHTS_API_KEY
+      #     value: "YOUR_API_KEY_HERE"
+      #   - name: POSTMAN_INSIGHTS_PROJECT_ID
+      #     value: "YOUR_PROJECT_ID_HERE"

--- a/k8s/test-pod.yaml
+++ b/k8s/test-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-app
+  namespace: postman-insights-namespace
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      env:
+        - name: POSTMAN_INSIGHTS_API_KEY
+          value: "YOUR_API_KEY_HERE"
+        - name: POSTMAN_INSIGHTS_PROJECT_ID
+          value: "YOUR_PROJECT_ID_HERE"
+      ports:
+        - containerPort: 80

--- a/pcap/ecapture_text_reader.go
+++ b/pcap/ecapture_text_reader.go
@@ -1,0 +1,311 @@
+package pcap
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+)
+
+// EcaptureTextReader reads eCapture text output from stdout and produces RawFrames
+type EcaptureTextReader struct {
+	reader       io.Reader
+	frameChan    chan RawFrame
+	errChan      chan error
+	ctx          context.Context
+	cancel       context.CancelFunc
+	podName      string
+	frameBuffer  []string // Accumulates lines for current frame
+	lastUUIDLine string   // Most recent line containing UUID metadata
+}
+
+// NewEcaptureTextReader creates a reader for eCapture text mode output
+func NewEcaptureTextReader(reader io.Reader, podName string) *EcaptureTextReader {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &EcaptureTextReader{
+		reader:      reader,
+		frameChan:   make(chan RawFrame, 100), // Buffer to prevent blocking
+		errChan:     make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+		podName:     podName,
+		frameBuffer: make([]string, 0, 50),
+	}
+}
+
+// Start begins reading from stdout and sending frames to the channel
+func (r *EcaptureTextReader) Start() {
+	printer.Infof("🔥 DEBUG: Text reader started for pod %s\n", r.podName)
+	go r.readLoop()
+}
+
+// FrameChannel returns the channel where parsed frames are sent
+func (r *EcaptureTextReader) FrameChannel() <-chan RawFrame {
+	return r.frameChan
+}
+
+// ErrorChannel returns the channel where errors are sent
+func (r *EcaptureTextReader) ErrorChannel() <-chan error {
+	return r.errChan
+}
+
+// Stop stops the reader and closes channels
+func (r *EcaptureTextReader) Stop() {
+	r.cancel()
+}
+
+// readLoop continuously reads from stdout and accumulates frames
+func (r *EcaptureTextReader) readLoop() {
+	defer close(r.frameChan)
+	defer close(r.errChan)
+
+	scanner := bufio.NewScanner(r.reader)
+	// Increase buffer size to handle large frames (1MB max)
+	buf := make([]byte, 1024*1024)
+	scanner.Buffer(buf, len(buf))
+
+	lastLineTime := time.Now()
+	frameTimeout := 5 * time.Second
+
+	// Goroutine to check for timeouts
+	timeoutTicker := time.NewTicker(1 * time.Second)
+	defer timeoutTicker.Stop()
+
+	go func() {
+		for {
+			select {
+			case <-r.ctx.Done():
+				return
+			case <-timeoutTicker.C:
+				// Check if we have buffered lines that haven't been completed
+				if len(r.frameBuffer) > 0 && time.Since(lastLineTime) > frameTimeout {
+					printer.Debugf("Frame timeout for pod %s, flushing %d buffered lines\n",
+						r.podName, len(r.frameBuffer))
+					r.flushFrame("timeout")
+				}
+			}
+		}
+	}()
+
+	linesRead := 0
+	for scanner.Scan() {
+		select {
+		case <-r.ctx.Done():
+			return
+		default:
+		}
+
+		line := scanner.Text()
+		lastLineTime = time.Now()
+		linesRead++
+
+		// Log first few lines to verify we're reading data
+		if linesRead <= 10 {
+			printer.Infof("🔥 DEBUG: Text reader line %d for pod %s: %s\n", linesRead, r.podName, line)
+		} else if linesRead == 11 {
+			printer.Infof("🔥 DEBUG: Text reader receiving data for pod %s (suppressing further line logs)\n", r.podName)
+		}
+
+		// Skip completely empty lines if buffer is empty
+		if len(r.frameBuffer) == 0 && strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Check if this line starts a new frame
+		if r.isFrameStart(line) {
+			// Flush previous frame if any
+			if len(r.frameBuffer) > 0 {
+				r.flushFrame("")
+			}
+		}
+
+		// Add line to buffer
+		r.frameBuffer = append(r.frameBuffer, line)
+
+		// Track UUID metadata for use when parsing frames
+		if strings.Contains(line, "UUID:") {
+			r.lastUUIDLine = line
+		}
+
+		// Check if this line ends the current frame
+		if r.isFrameEnd(line) {
+			r.flushFrame("")
+		}
+	}
+
+	// Check for scanner errors
+	if err := scanner.Err(); err != nil {
+		printer.Errorf("Error reading eCapture output for pod %s: %v\n", r.podName, err)
+		select {
+		case r.errChan <- err:
+		case <-r.ctx.Done():
+		}
+	}
+
+	// Flush any remaining buffered lines
+	if len(r.frameBuffer) > 0 {
+		r.flushFrame("eof")
+	}
+}
+
+// isFrameStart determines if a line marks the beginning of a new frame
+func (r *EcaptureTextReader) isFrameStart(line string) bool {
+	trimmed := strings.TrimSpace(line)
+
+	// HTTP/2: "Frame Type => HEADERS" or "Frame Type\t=>\tHEADERS" (with tabs)
+	// Normalize whitespace to handle both spaces and tabs
+	normalizedLine := strings.Join(strings.Fields(trimmed), " ")
+	if strings.HasPrefix(normalizedLine, "Frame Type =>") {
+		return true
+	}
+
+	// HTTP/1.1 Request: HTTP method at start of line
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "CONNECT", "TRACE"} {
+		if strings.HasPrefix(trimmed, method+" ") {
+			return true
+		}
+	}
+
+	// HTTP/1.1 Response: "HTTP/1.x" at start
+	if strings.HasPrefix(trimmed, "HTTP/1.") {
+		return true
+	}
+
+	return false
+}
+
+// isFrameEnd determines if a line marks the end of the current frame
+func (r *EcaptureTextReader) isFrameEnd(line string) bool {
+	// Empty line typically marks end of headers in HTTP/1.1
+	// For HTTP/2, we'll rely on detecting the next frame start
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" && len(r.frameBuffer) > 1 {
+		// Only consider empty line as end if we have content
+		return true
+	}
+
+	// For HTTP/2 DATA frames, we need to handle body content
+	// This is a simple heuristic - in practice, may need refinement
+	if len(r.frameBuffer) > 0 {
+		firstLine := strings.TrimSpace(r.frameBuffer[0])
+		if strings.Contains(firstLine, "Frame Type => DATA") {
+			// DATA frames might have body content
+			// For now, consider them complete after a few lines
+			if len(r.frameBuffer) >= 10 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// flushFrame sends the accumulated buffer as a RawFrame
+func (r *EcaptureTextReader) flushFrame(reason string) {
+	if len(r.frameBuffer) == 0 {
+		return
+	}
+
+	// If the buffer lacks UUID metadata but we have a recent UUID line, prepend it for downstream parsing.
+	if !bufferHasUUID(r.frameBuffer) && r.lastUUIDLine != "" && bufferHasFrameType(r.frameBuffer) {
+		r.frameBuffer = append([]string{r.lastUUIDLine}, r.frameBuffer...)
+	}
+
+	// Determine frame type from buffered lines
+	frameType := r.detectFrameType(r.frameBuffer)
+
+	frame := RawFrame{
+		FrameType: frameType,
+		Lines:     make([]string, len(r.frameBuffer)),
+		Timestamp: time.Now(),
+	}
+
+	// Copy buffer to frame
+	copy(frame.Lines, r.frameBuffer)
+
+	// Send frame to channel (non-blocking with timeout)
+	select {
+	case r.frameChan <- frame:
+		printer.Infof("🔥 DEBUG: Flushed %s frame for pod %s (%d lines)%s - FIRST LINE: %s\n",
+			frameType, r.podName, len(frame.Lines),
+			func() string {
+				if reason != "" {
+					return " [" + reason + "]"
+				}
+				return ""
+			}(),
+			func() string {
+				if len(frame.Lines) > 0 {
+					if len(frame.Lines[0]) > 100 {
+						return frame.Lines[0][:100] + "..."
+					}
+					return frame.Lines[0]
+				}
+				return "(no lines)"
+			}())
+	case <-time.After(1 * time.Second):
+		printer.Warningf("Frame channel blocked for pod %s, dropping frame\n", r.podName)
+	case <-r.ctx.Done():
+		return
+	}
+
+	// Clear buffer for next frame
+	r.frameBuffer = r.frameBuffer[:0]
+}
+
+// detectFrameType examines the first line to determine frame type
+func (r *EcaptureTextReader) detectFrameType(lines []string) string {
+	if len(lines) == 0 {
+		return "UNKNOWN"
+	}
+
+	// Scan for explicit frame type markers anywhere in the buffer.
+	for _, l := range lines {
+		normalizedLine := strings.Join(strings.Fields(strings.TrimSpace(l)), " ")
+		if strings.HasPrefix(normalizedLine, "Frame Type =>") {
+			parts := strings.SplitN(normalizedLine, "=>", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+			return "HTTP2_UNKNOWN"
+		}
+	}
+
+	trimmed := strings.TrimSpace(lines[0])
+
+	// HTTP/1.1 request
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "CONNECT", "TRACE"} {
+		if strings.HasPrefix(trimmed, method+" ") {
+			return "HTTP1_REQUEST"
+		}
+	}
+
+	// HTTP/1.1 response
+	if strings.HasPrefix(trimmed, "HTTP/1.") {
+		return "HTTP1_RESPONSE"
+	}
+
+	return "UNKNOWN"
+}
+
+func bufferHasUUID(lines []string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, "UUID:") {
+			return true
+		}
+	}
+	return false
+}
+
+func bufferHasFrameType(lines []string) bool {
+	for _, l := range lines {
+		normalized := strings.Join(strings.Fields(strings.TrimSpace(l)), " ")
+		if strings.HasPrefix(normalized, "Frame Type =>") {
+			return true
+		}
+	}
+	return false
+}

--- a/pcap/net_parse.go
+++ b/pcap/net_parse.go
@@ -102,6 +102,13 @@ func NewNetworkTrafficParser(serviceID akid.ServiceID, traceTags map[tags.Key]st
 	}
 }
 
+// SetPcapWrapper replaces the default pcapWrapper with a custom implementation.
+// This allows using alternative packet sources (e.g., file readers instead of live capture).
+// Should be called before ParseFromInterface.
+func (p *NetworkTrafficParser) SetPcapWrapper(wrapper pcapWrapper) {
+	p.pcap = wrapper
+}
+
 // Replace the current per-packet callback. Should be called before starting
 // ParseFromInterface.
 func (p *NetworkTrafficParser) InstallObserver(observer NetworkTrafficObserver) {

--- a/pcap/text_collector.go
+++ b/pcap/text_collector.go
@@ -1,0 +1,454 @@
+package pcap
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/akitasoftware/akita-libs/akid"
+	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/akitasoftware/akita-libs/memview"
+	"github.com/akitasoftware/akita-libs/tags"
+	"github.com/google/uuid"
+	"github.com/postmanlabs/postman-insights-agent/printer"
+	"github.com/postmanlabs/postman-insights-agent/telemetry"
+	"github.com/postmanlabs/postman-insights-agent/trace"
+)
+
+type streamState struct {
+	req     *ParsedRequest
+	resp    *ParsedResponse
+	created time.Time
+}
+
+var (
+	witnessDebugPath = os.Getenv("HTTPS_WITNESS_DEBUG_PATH")
+	witnessDebugMu   sync.Mutex
+)
+
+// CollectFromTextFrames reads parsed HTTP frames from eCapture text mode and processes them.
+// This replaces the file-based approach with direct in-memory streaming.
+//
+// Unlike Collect() and CollectFromFile(), this function:
+// - Reads from a frame channel (from eCapture stdout)
+// - Uses text_parser to convert frames to HTTP requests
+// - Does not require gopacket or pcapng parsing
+// - Never writes plaintext to disk
+func CollectFromTextFrames(
+	serviceID akid.ServiceID,
+	traceTags map[tags.Key]string,
+	stop <-chan struct{},
+	frameChan <-chan RawFrame,
+	proc trace.Collector,
+	telemetry telemetry.Tracker,
+) error {
+	defer proc.Close()
+
+	startTime := time.Now()
+	processedFrames := 0
+	parsedRequests := 0
+	unparsedFrames := 0
+	intervalLength := 1 * time.Minute
+	streams := make(map[uuid.UUID]*streamState)
+
+	podName, ok := traceTags[tags.XAkitaKubernetesPod]
+	if !ok {
+		podName = "unknown"
+	}
+
+	printer.Infof("🔥 DEBUG: Starting HTTPS text frame collector for pod %s\n", podName)
+	printer.Infof("🔥 DEBUG: Waiting for frames from channel...\n")
+
+	for {
+		select {
+		case <-stop:
+			printer.Infof("HTTPS text collector stopped for pod %s (processed: %d, parsed: %d, unparsed: %d)\n",
+				podName, processedFrames, parsedRequests, unparsedFrames)
+			return nil
+
+		case frame, ok := <-frameChan:
+			if !ok {
+				// Channel closed - eCapture process ended
+				printer.Infof("HTTPS frame channel closed for pod %s (processed: %d, parsed: %d, unparsed: %d)\n",
+					podName, processedFrames, parsedRequests, unparsedFrames)
+				return nil
+			}
+
+			processedFrames++
+
+			printer.Infof("🔥 DEBUG: Received frame %d for pod %s: type=%s, lines=%d\n",
+				processedFrames, podName, frame.FrameType, len(frame.Lines))
+
+			// Log progress periodically
+			if processedFrames%10 == 0 {
+				printer.Debugf("HTTPS collector for pod %s: processed %d frames (%d parsed, %d unparsed)\n",
+					podName, processedFrames, parsedRequests, unparsedFrames)
+			}
+
+			// Periodic stats logging
+			now := time.Now()
+			if now.Sub(startTime) >= intervalLength {
+				printer.Infof("HTTPS stats for pod %s: %d frames/min (%d parsed, %d unparsed)\n",
+					podName, processedFrames, parsedRequests, unparsedFrames)
+				processedFrames = 0
+				parsedRequests = 0
+				unparsedFrames = 0
+				startTime = now
+			}
+
+			// Parse the frame
+			result, err := ParseFrame(frame)
+			if err != nil {
+				printer.Debugf("Error parsing frame for pod %s: %v\n", podName, err)
+				unparsedFrames++
+				continue
+			}
+
+			// Handle different result types
+			switch v := result.(type) {
+			case *ParsedRequest:
+				parsedRequests++
+
+				printer.Infof("HTTPS request parsed for pod %s: %s %s (version=%s, headers=%d, body=%d bytes)\n",
+					podName, v.Method, v.Path, v.Version, len(v.Headers), len(v.Body))
+
+				if v.Version == "HTTP/2" {
+					st := ensureStream(streams, v.StreamID, v.Timestamp)
+					// If we accumulated body from DATA before HEADERS, merge it.
+					if st.req != nil && len(st.req.Body) > 0 {
+						v.Body = append(st.req.Body, v.Body...)
+					}
+					st.req = v
+					if v.EndStream {
+						sendRequestWitness(proc, podName, st.req)
+						st.req = nil
+						cleanupStream(streams, v.StreamID)
+					}
+					continue
+				}
+
+				sendRequestWitness(proc, podName, v)
+
+			case *ParsedResponse:
+				if v.Version == "HTTP/2" {
+					st := ensureStream(streams, v.StreamID, v.Timestamp)
+					if st.resp != nil && len(st.resp.Body) > 0 {
+						v.Body = append(st.resp.Body, v.Body...)
+					}
+					// If we already buffered a request, send it before the response for pairing.
+					if st.req != nil && st.req.Method != "" && st.req.Path != "" {
+						sendRequestWitness(proc, podName, st.req)
+						st.req = nil
+					}
+					st.resp = v
+					if v.EndStream {
+						sendResponseWitness(proc, podName, st.resp)
+						st.resp = nil
+						cleanupStream(streams, v.StreamID)
+					}
+					continue
+				}
+
+				sendResponseWitness(proc, podName, v)
+
+			case *ParsedDataFrame:
+				st := ensureStream(streams, v.StreamID, v.Timestamp)
+				printer.Debugf("🔥 DEBUG: HTTP/2 DATA frame for pod %s stream=%s resp=%v end=%v payload_bytes=%d\n",
+					podName, v.StreamID.String(), v.IsResponse, v.EndStream, len(v.Payload))
+				if v.IsResponse {
+					if st.resp == nil {
+						st.resp = &ParsedResponse{
+							StreamID:  v.StreamID,
+							Headers:   make(map[string]string),
+							Version:   "HTTP/2",
+							Timestamp: v.Timestamp,
+						}
+					}
+					st.resp.Body = append(st.resp.Body, v.Payload...)
+					if v.EndStream && st.resp.Status != 0 {
+						// If request exists, send it first.
+						if st.req != nil && st.req.Method != "" && st.req.Path != "" {
+							sendRequestWitness(proc, podName, st.req)
+							st.req = nil
+						}
+						sendResponseWitness(proc, podName, st.resp)
+						st.resp = nil
+						cleanupStream(streams, v.StreamID)
+					}
+				} else {
+					if st.req == nil {
+						st.req = &ParsedRequest{
+							StreamID:  v.StreamID,
+							Headers:   make(map[string]string),
+							Version:   "HTTP/2",
+							Timestamp: v.Timestamp,
+						}
+					}
+					st.req.Body = append(st.req.Body, v.Payload...)
+					if v.EndStream && st.req.Method != "" && st.req.Path != "" {
+						sendRequestWitness(proc, podName, st.req)
+						st.req = nil
+						cleanupStream(streams, v.StreamID)
+					}
+				}
+
+			case *UnparsedRecord:
+				unparsedFrames++
+
+				// Log unparsed records for debugging (without leaking plaintext)
+				printer.Debugf("Unparsed frame for pod %s: protocol=%s, error=%s, bytes=%d, sample=%s\n",
+					podName, v.Protocol, v.ErrorType, v.Bytes, v.RawSample)
+
+				// TODO: Report unparsed frame metrics to telemetry
+				// telemetry.ReportUnparsedFrame(v.Protocol, v.ErrorType, v.Bytes)
+
+			default:
+				printer.Warningf("Unknown parse result type for pod %s: %T\n", podName, result)
+			}
+
+			flushTimedOutStreams(streams, 2*time.Second, proc, podName)
+		}
+	}
+}
+
+func ensureStream(streams map[uuid.UUID]*streamState, id uuid.UUID, ts time.Time) *streamState {
+	if st, ok := streams[id]; ok {
+		if st.req != nil && st.req.Timestamp.IsZero() {
+			st.req.Timestamp = ts
+		}
+		if st.resp != nil && st.resp.Timestamp.IsZero() {
+			st.resp.Timestamp = ts
+		}
+		return st
+	}
+	st := &streamState{created: ts}
+	streams[id] = st
+	return st
+}
+
+func cleanupStream(streams map[uuid.UUID]*streamState, id uuid.UUID) {
+	if st, ok := streams[id]; ok {
+		if st.req == nil && st.resp == nil {
+			delete(streams, id)
+		}
+	}
+}
+
+func sendRequestWitness(proc trace.Collector, podName string, req *ParsedRequest) {
+	if req == nil {
+		return
+	}
+	witness, err := convertRequestToWitness(req)
+	if err != nil {
+		printer.Warningf("Failed to convert parsed request to witness for pod %s: %v\n", podName, err)
+		return
+	}
+	witness.Interface = "https-capture"
+	if err := proc.Process(witness); err != nil {
+		printer.Warningf("Failed to process HTTPS witness for pod %s: %v\n", podName, err)
+	} else {
+		printer.Infof("✅ Successfully sent HTTPS witness to backend: %s %s (body=%d bytes)\n", req.Method, req.Path, len(req.Body))
+		dumpWitnessIfEnabled(witness)
+	}
+}
+
+func sendResponseWitness(proc trace.Collector, podName string, resp *ParsedResponse) {
+	if resp == nil {
+		return
+	}
+	witness, err := convertResponseToWitness(resp)
+	if err != nil {
+		printer.Warningf("Failed to convert parsed response to witness for pod %s: %v\n", podName, err)
+		return
+	}
+	witness.Interface = "https-capture"
+	if err := proc.Process(witness); err != nil {
+		printer.Warningf("Failed to process HTTPS response witness for pod %s: %v\n", podName, err)
+	} else {
+		printer.Infof("✅ Successfully sent HTTPS response witness to backend: %d (body=%d bytes)\n", resp.Status, len(resp.Body))
+		dumpWitnessIfEnabled(witness)
+	}
+}
+
+// dumpWitnessIfEnabled writes witnesses to a debug file if HTTPS_WITNESS_DEBUG_PATH is set.
+// This is intended for short-lived debugging; file may contain sensitive payloads.
+func dumpWitnessIfEnabled(w akinet.ParsedNetworkTraffic) {
+	if witnessDebugPath == "" {
+		return
+	}
+
+	record := map[string]interface{}{
+		"src":        map[string]interface{}{"ip": w.SrcIP.String(), "port": w.SrcPort},
+		"dst":        map[string]interface{}{"ip": w.DstIP.String(), "port": w.DstPort},
+		"timestamp":  w.ObservationTime,
+		"interface":  w.Interface,
+		"content_ts": w.FinalPacketTime,
+	}
+
+	streamID := ""
+	switch v := w.Content.(type) {
+	case akinet.HTTPRequest:
+		streamID = v.StreamID.String()
+		record["type"] = "request"
+		record["method"] = v.Method
+		record["path"] = v.URL.String()
+		record["host"] = v.Host
+		record["status"] = nil
+		record["headers"] = v.Header
+		record["body"] = v.Body.String()
+	case akinet.HTTPResponse:
+		streamID = v.StreamID.String()
+		record["type"] = "response"
+		record["status"] = v.StatusCode
+		record["headers"] = v.Header
+		record["body"] = v.Body.String()
+	default:
+		record["type"] = "unknown"
+	}
+	record["stream_id"] = streamID
+
+	buf, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+
+	witnessDebugMu.Lock()
+	defer witnessDebugMu.Unlock()
+	f, err := os.OpenFile(witnessDebugPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(buf, '\n'))
+}
+
+func flushTimedOutStreams(streams map[uuid.UUID]*streamState, timeout time.Duration, proc trace.Collector, podName string) {
+	now := time.Now()
+	for id, st := range streams {
+		if st.req != nil && st.req.Method != "" && st.req.Path != "" && (st.req.EndStream || now.Sub(st.created) > timeout) {
+			sendRequestWitness(proc, podName, st.req)
+			st.req = nil
+		}
+		if st.resp != nil && st.resp.Status != 0 && (st.resp.EndStream || now.Sub(st.created) > timeout) {
+			sendResponseWitness(proc, podName, st.resp)
+			st.resp = nil
+		}
+		cleanupStream(streams, id)
+	}
+}
+
+// convertRequestToWitness converts a ParsedRequest to akinet.ParsedNetworkTraffic
+// This creates a witness record that can be sent to the backend
+func convertRequestToWitness(req *ParsedRequest) (akinet.ParsedNetworkTraffic, error) {
+	// Parse the URL from the path
+	parsedURL, err := url.Parse(req.Path)
+	if err != nil {
+		// If path doesn't parse as full URL, treat it as path-only
+		parsedURL = &url.URL{Path: req.Path}
+	}
+
+	// Convert headers map to http.Header
+	headers := make(http.Header)
+	for k, v := range req.Headers {
+		headers.Set(k, v)
+	}
+
+	// Determine protocol version (HTTP/1.1 or HTTP/2)
+	protoMajor, protoMinor := 1, 1 // Default to HTTP/1.1
+	if req.Version == "HTTP/2" {
+		protoMajor, protoMinor = 2, 0
+	}
+
+	// Get host from headers or URL
+	host := req.Headers["Host"]
+	if host == "" {
+		host = parsedURL.Host
+	}
+
+	// Create akinet.HTTPRequest
+	httpReq := akinet.HTTPRequest{
+		StreamID:   req.StreamID,
+		Seq:        0, // We don't have TCP sequence numbers from eCapture text mode
+		Method:     req.Method,
+		ProtoMajor: protoMajor,
+		ProtoMinor: protoMinor,
+		URL:        parsedURL,
+		Host:       host,
+		Header:     headers,
+		Body:       memview.New(req.Body), // memview.New takes []byte directly
+	}
+
+	// Create ParsedNetworkTraffic witness
+	// Since eCapture text mode doesn't provide IP/port info, use placeholder values
+	witness := akinet.ParsedNetworkTraffic{
+		SrcIP:           net.ParseIP("0.0.0.0"),
+		SrcPort:         0,
+		DstIP:           net.ParseIP("0.0.0.0"),
+		DstPort:         443, // Default HTTPS port
+		Content:         httpReq,
+		ObservationTime: req.Timestamp,
+		FinalPacketTime: req.Timestamp,
+	}
+
+	return witness, nil
+}
+
+// convertResponseToWitness converts a ParsedResponse to akinet.ParsedNetworkTraffic
+func convertResponseToWitness(resp *ParsedResponse) (akinet.ParsedNetworkTraffic, error) {
+	// Convert headers map to http.Header
+	headers := make(http.Header)
+	for k, v := range resp.Headers {
+		headers.Set(k, v)
+	}
+
+	protoMajor, protoMinor := 1, 1
+	if resp.Version == "HTTP/2" {
+		protoMajor, protoMinor = 2, 0
+	}
+
+	httpResp := akinet.HTTPResponse{
+		StreamID:   resp.StreamID,
+		Seq:        0,
+		StatusCode: resp.Status,
+		ProtoMajor: protoMajor,
+		ProtoMinor: protoMinor,
+		Header:     headers,
+		Body:       memview.New(resp.Body),
+	}
+
+	witness := akinet.ParsedNetworkTraffic{
+		SrcIP:           net.ParseIP("0.0.0.0"),
+		SrcPort:         0,
+		DstIP:           net.ParseIP("0.0.0.0"),
+		DstPort:         443,
+		Content:         httpResp,
+		ObservationTime: resp.Timestamp,
+		FinalPacketTime: resp.Timestamp,
+	}
+
+	return witness, nil
+}
+
+// StartHTTPSTextCollector is a helper to start the text collector goroutine
+// This is called from apidump when HTTPS capture is enabled
+func StartHTTPSTextCollector(
+	serviceID akid.ServiceID,
+	traceTags map[tags.Key]string,
+	stop <-chan struct{},
+	frameChan <-chan RawFrame,
+	proc trace.Collector,
+	telemetry telemetry.Tracker,
+) error {
+	return CollectFromTextFrames(
+		serviceID,
+		traceTags,
+		stop,
+		frameChan,
+		proc,
+		telemetry,
+	)
+}

--- a/pcap/text_parser.go
+++ b/pcap/text_parser.go
@@ -1,0 +1,568 @@
+package pcap
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ParsedRequest represents a successfully parsed HTTP request (HTTP/1.1 or HTTP/2)
+type ParsedRequest struct {
+	StreamID  uuid.UUID
+	Method    string
+	Path      string
+	Headers   map[string]string
+	Body      []byte
+	Version   string // "HTTP/1.1" or "HTTP/2"
+	Timestamp time.Time
+	EndStream bool
+}
+
+// ParsedResponse represents a successfully parsed HTTP response (HTTP/1.1 or HTTP/2)
+type ParsedResponse struct {
+	StreamID  uuid.UUID
+	Status    int
+	Headers   map[string]string
+	Body      []byte
+	Version   string // "HTTP/1.1" or "HTTP/2"
+	Timestamp time.Time
+	EndStream bool
+}
+
+// ParsedDataFrame represents HTTP/2 DATA frames
+type ParsedDataFrame struct {
+	StreamID   uuid.UUID
+	Payload    []byte
+	IsResponse bool
+	EndStream  bool
+	Timestamp  time.Time
+}
+
+// UnparsedRecord represents a frame that could not be parsed
+// Used for telemetry/metrics without exposing full plaintext
+type UnparsedRecord struct {
+	Bytes     int    // Approximate byte count
+	Protocol  string // Best guess: "HTTP/2", "HTTP/1.1", "Unknown"
+	ErrorType string // "malformed_headers", "timeout", "buffer_overflow", etc.
+	Timestamp time.Time
+	RawSample string // First 200 chars for debugging (never full plaintext)
+}
+
+// RawFrame represents a logical frame from eCapture text output
+type RawFrame struct {
+	FrameType string   // "HEADERS", "DATA", "HTTP1_REQUEST", "HTTP1_RESPONSE"
+	Lines     []string // Raw text lines
+	Timestamp time.Time
+}
+
+// Protocol detection
+type Protocol int
+
+const (
+	ProtocolUnknown Protocol = iota
+	ProtocolHTTP1
+	ProtocolHTTP2
+)
+
+// DetectProtocol examines the first few lines to determine HTTP/1.1 vs HTTP/2
+func DetectProtocol(frame RawFrame) Protocol {
+	if len(frame.Lines) == 0 {
+		return ProtocolUnknown
+	}
+
+	// Scan lines to detect HTTP/2 markers even if a metadata line precedes the frame.
+	for _, raw := range frame.Lines {
+		line := strings.TrimSpace(raw)
+		normalizedLine := strings.Join(strings.Fields(line), " ")
+		if strings.HasPrefix(normalizedLine, "Frame Type =>") || strings.Contains(line, "Frame Type") && strings.Contains(line, "=>") {
+			return ProtocolHTTP2
+		}
+	}
+
+	firstLine := strings.TrimSpace(frame.Lines[0])
+
+	// HTTP/1.1 Request: "GET /path HTTP/1.1"
+	for _, method := range []string{"GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "CONNECT", "TRACE"} {
+		if strings.HasPrefix(firstLine, method+" ") {
+			return ProtocolHTTP1
+		}
+	}
+
+	// HTTP/1.1 Response: "HTTP/1.1 200 OK"
+	if strings.HasPrefix(firstLine, "HTTP/1.") {
+		return ProtocolHTTP1
+	}
+
+	return ProtocolUnknown
+}
+
+// ParseFrame is the main entry point for parsing
+func ParseFrame(frame RawFrame) (interface{}, error) {
+	protocol := DetectProtocol(frame)
+
+	switch protocol {
+	case ProtocolHTTP2:
+		if strings.EqualFold(frame.FrameType, "DATA") {
+			return ParseHTTP2DataFrame(frame)
+		}
+		return ParseHTTP2Frame(frame)
+	case ProtocolHTTP1:
+		firstLine := strings.TrimSpace(frame.Lines[0])
+		if strings.HasPrefix(firstLine, "HTTP/1.") {
+			return ParseHTTP1Response(frame)
+		}
+		return ParseHTTP1Request(frame)
+	default:
+		// Fallback: create unparsed record
+		return CreateUnparsedRecord(frame, "unknown_protocol", nil), nil
+	}
+}
+
+// ParseHTTP1Request parses HTTP/1.1 requests
+func ParseHTTP1Request(frame RawFrame) (*ParsedRequest, error) {
+	if len(frame.Lines) == 0 {
+		return nil, errors.New("empty frame")
+	}
+
+	// Derive a deterministic stream ID based on any UUID marker in the frame
+	streamID := deriveStreamID(frame)
+
+	// Parse request line: "GET /path HTTP/1.1"
+	requestLine := strings.TrimSpace(frame.Lines[0])
+	parts := strings.SplitN(requestLine, " ", 3)
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid request line: %s", requestLine)
+	}
+
+	req := &ParsedRequest{
+		StreamID:  streamID,
+		Method:    parts[0],
+		Path:      parts[1],
+		Version:   parts[2],
+		Headers:   make(map[string]string),
+		Timestamp: frame.Timestamp,
+	}
+
+	// Parse headers (simple "Key: Value" format)
+	bodyStart := -1
+	for i := 1; i < len(frame.Lines); i++ {
+		line := strings.TrimSpace(frame.Lines[i])
+
+		// Empty line marks end of headers
+		if line == "" {
+			bodyStart = i + 1
+			break
+		}
+
+		// Split on first ": "
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) == 2 {
+			req.Headers[parts[0]] = parts[1]
+		}
+	}
+
+	// Handle body (if Content-Length present)
+	if bodyStart > 0 && bodyStart < len(frame.Lines) {
+		if contentLen := req.Headers["Content-Length"]; contentLen != "" {
+			length, err := strconv.Atoi(contentLen)
+			if err == nil && length > 0 {
+				// Accumulate remaining lines as body
+				bodyLines := frame.Lines[bodyStart:]
+				bodyText := strings.Join(bodyLines, "\n")
+				req.Body = []byte(bodyText)
+
+				// Trim to Content-Length if we have more data
+				if len(req.Body) > length {
+					req.Body = req.Body[:length]
+				}
+			}
+		}
+	}
+
+	return req, nil
+}
+
+// ParseHTTP1Response parses HTTP/1.1 responses
+func ParseHTTP1Response(frame RawFrame) (*ParsedResponse, error) {
+	if len(frame.Lines) == 0 {
+		return nil, errors.New("empty frame")
+	}
+
+	streamID := deriveStreamID(frame)
+
+	// Parse status line: "HTTP/1.1 200 OK"
+	statusLine := strings.TrimSpace(frame.Lines[0])
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid status line: %s", statusLine)
+	}
+
+	statusCode, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid status code: %s", parts[1])
+	}
+
+	resp := &ParsedResponse{
+		StreamID:  streamID,
+		Status:    statusCode,
+		Version:   parts[0],
+		Headers:   make(map[string]string),
+		Timestamp: frame.Timestamp,
+	}
+
+	// Parse headers
+	bodyStart := -1
+	for i := 1; i < len(frame.Lines); i++ {
+		line := strings.TrimSpace(frame.Lines[i])
+
+		if line == "" {
+			bodyStart = i + 1
+			break
+		}
+
+		parts := strings.SplitN(line, ": ", 2)
+		if len(parts) == 2 {
+			resp.Headers[parts[0]] = parts[1]
+		}
+	}
+
+	// Handle body (if Content-Length present)
+	if bodyStart > 0 && bodyStart < len(frame.Lines) {
+		if contentLen := resp.Headers["Content-Length"]; contentLen != "" {
+			length, err := strconv.Atoi(contentLen)
+			if err == nil && length > 0 {
+				bodyLines := frame.Lines[bodyStart:]
+				bodyText := strings.Join(bodyLines, "\n")
+				resp.Body = []byte(bodyText)
+				if len(resp.Body) > length {
+					resp.Body = resp.Body[:length]
+				}
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+// ParseHTTP2Frame parses HTTP/2 HEADERS frames from eCapture text output
+func ParseHTTP2Frame(frame RawFrame) (interface{}, error) {
+	if len(frame.Lines) == 0 {
+		return nil, errors.New("empty frame")
+	}
+
+	streamID := deriveStreamID(frame)
+
+	// eCapture emits a metadata line followed by "Frame Type => HEADERS".
+	// Find the first line that actually contains "Frame Type".
+	startIdx := -1
+	for i, l := range frame.Lines {
+		if strings.Contains(strings.Join(strings.Fields(strings.TrimSpace(l)), " "), "Frame Type =>") {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx == -1 {
+		return nil, fmt.Errorf("no frame type marker found")
+	}
+
+	lines := frame.Lines[startIdx:]
+
+	// Verify this is a HEADERS frame (handle both spaces and tabs)
+	firstLine := strings.TrimSpace(lines[0])
+	normalizedFirst := strings.Join(strings.Fields(firstLine), " ")
+	if !strings.Contains(normalizedFirst, "Frame Type") || !strings.Contains(normalizedFirst, "HEADERS") {
+		return nil, fmt.Errorf("not a HEADERS frame: %s", firstLine)
+	}
+
+	headers := make(map[string]string)
+	req := &ParsedRequest{
+		StreamID:  streamID,
+		Headers:   headers,
+		Version:   "HTTP/2",
+		Timestamp: frame.Timestamp,
+	}
+	resp := &ParsedResponse{
+		StreamID:  streamID,
+		Headers:   headers,
+		Version:   "HTTP/2",
+		Timestamp: frame.Timestamp,
+	}
+
+	// Track flags for END_STREAM
+	var flagsLine string
+
+	// Parse header fields
+	// Format: header field "key" = "value" or header field\t"key"\t=\t"value" (with tabs)
+	for i := 1; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+
+		// Stop at next frame or empty line
+		if line == "" || strings.Contains(line, "Frame Type") {
+			break
+		}
+
+		// Capture flags
+		if strings.HasPrefix(line, "Flags") {
+			flagsLine = line
+		}
+
+		// Parse: header field "key" = "value" (handle tabs and spaces)
+		if !strings.Contains(line, "header field") {
+			continue
+		}
+
+		// Normalize whitespace for parsing
+		normalizedLine := strings.Join(strings.Fields(line), " ")
+
+		// Remove "header field " prefix
+		if !strings.HasPrefix(normalizedLine, "header field ") {
+			continue
+		}
+		kvPart := normalizedLine[13:]
+
+		// Split on " = " (after normalization)
+		parts := strings.SplitN(kvPart, " = ", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		// Remove quotes from key and value
+		key := strings.Trim(parts[0], `"`)
+		value := strings.Trim(parts[1], `"`)
+
+		// Handle pseudo-headers
+		switch key {
+		case ":method":
+			req.Method = value
+		case ":path":
+			req.Path = value
+		case ":authority":
+			headers["Host"] = value
+		case ":scheme":
+			headers["X-Scheme"] = value
+		case ":status":
+			statusCode, err := strconv.Atoi(value)
+			if err == nil {
+				resp.Status = statusCode
+			}
+		default:
+			// Regular header
+			headers[key] = value
+		}
+	}
+
+	// Decide whether this is a request or response based on pseudo-headers
+	if req.Method != "" && req.Path != "" {
+		req.EndStream = strings.Contains(flagsLine, "END_STREAM")
+		return req, nil
+	}
+	if resp.Status != 0 {
+		resp.EndStream = strings.Contains(flagsLine, "END_STREAM")
+		return resp, nil
+	}
+
+	return nil, errors.New("missing required HTTP/2 pseudo-headers")
+}
+
+// CreateUnparsedRecord creates a fallback record for unparsable frames
+func CreateUnparsedRecord(frame RawFrame, errorType string, err error) *UnparsedRecord {
+	// Estimate byte count from lines
+	totalBytes := 0
+	for _, line := range frame.Lines {
+		totalBytes += len(line) + 1 // +1 for newline
+	}
+
+	// Create sample (first 200 chars, never full plaintext)
+	sample := strings.Join(frame.Lines, "\n")
+	if len(sample) > 200 {
+		sample = sample[:200] + "..."
+	}
+
+	// Determine protocol guess
+	protocol := "Unknown"
+	switch DetectProtocol(frame) {
+	case ProtocolHTTP1:
+		protocol = "HTTP/1.1"
+	case ProtocolHTTP2:
+		protocol = "HTTP/2"
+	}
+
+	record := &UnparsedRecord{
+		Bytes:     totalBytes,
+		Protocol:  protocol,
+		ErrorType: errorType,
+		Timestamp: frame.Timestamp,
+		RawSample: sample,
+	}
+
+	return record
+}
+
+// Helper: Truncate body if too large (prevent memory issues)
+func truncateBody(body []byte, maxLen int) []byte {
+	if len(body) > maxLen {
+		return body[:maxLen]
+	}
+	return body
+}
+
+// deriveStreamID creates a deterministic UUID using a normalized connection token and, when present,
+// an HTTP/2 stream identifier so requests and responses share the same key.
+func deriveStreamID(frame RawFrame) uuid.UUID {
+	connToken := normalizeConnToken(extractConnToken(frame))
+	streamToken := extractStreamIdentifier(frame)
+
+	switch {
+	case connToken != "" && streamToken != "":
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(connToken+"|"+streamToken))
+	case connToken != "":
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(connToken))
+	case streamToken != "":
+		return uuid.NewSHA1(uuid.NameSpaceOID, []byte(streamToken))
+	}
+
+	// Fallback to any UUID marker present.
+	for _, line := range frame.Lines {
+		if idx := strings.Index(line, "UUID:"); idx != -1 {
+			rest := line[idx+5:]
+			rest = strings.SplitN(rest, ",", 2)[0]
+			rest = strings.Fields(rest)[0]
+			return uuid.NewSHA1(uuid.NameSpaceOID, []byte(rest))
+		}
+	}
+	return uuid.New()
+}
+
+// ParseHTTP2DataFrame parses HTTP/2 DATA frames
+func ParseHTTP2DataFrame(frame RawFrame) (*ParsedDataFrame, error) {
+	streamID := deriveStreamID(frame)
+
+	// Find frame start
+	startIdx := -1
+	for i, l := range frame.Lines {
+		if strings.Contains(strings.Join(strings.Fields(strings.TrimSpace(l)), " "), "Frame Type =>") {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx == -1 {
+		return nil, errors.New("no frame marker found in DATA frame")
+	}
+	lines := frame.Lines[startIdx:]
+
+	endStream := false
+	isResp := isResponseFrame(frame)
+	payloadLines := make([]string, 0, len(lines))
+
+	for _, raw := range lines[1:] {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "Flags") {
+			if strings.Contains(line, "END_STREAM") {
+				endStream = true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "Length") || strings.HasPrefix(line, "Padding Length") || strings.HasPrefix(line, "Stream Identifier") {
+			continue
+		}
+		if strings.HasPrefix(strings.ToLower(line), "data") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				line = strings.TrimSpace(parts[1])
+			} else {
+				parts = strings.SplitN(line, "=>", 2)
+				if len(parts) == 2 {
+					line = strings.TrimSpace(parts[1])
+				}
+			}
+		}
+		if strings.HasPrefix(line, "Frame Type") {
+			continue
+		}
+		payloadLines = append(payloadLines, line)
+	}
+
+	payload := []byte(strings.Join(payloadLines, "\n"))
+
+	return &ParsedDataFrame{
+		StreamID:   streamID,
+		Payload:    payload,
+		IsResponse: isResp,
+		EndStream:  endStream,
+		Timestamp:  frame.Timestamp,
+	}, nil
+}
+
+func isResponseFrame(frame RawFrame) bool {
+	for _, line := range frame.Lines {
+		if strings.Contains(line, "HTTP2Response") || strings.Contains(line, "HTTP1Response") {
+			return true
+		}
+	}
+	// Heuristic: HTTP/1 metadata without method but with HTTP/1.x prefix
+	if len(frame.Lines) > 0 {
+		first := strings.TrimSpace(frame.Lines[0])
+		if strings.HasPrefix(first, "HTTP/1.") {
+			return true
+		}
+	}
+	return false
+}
+
+func extractConnToken(frame RawFrame) string {
+	for _, line := range frame.Lines {
+		if idx := strings.Index(line, "UUID:"); idx != -1 {
+			rest := line[idx+5:]
+			rest = strings.SplitN(rest, ",", 2)[0]
+			rest = strings.Fields(rest)[0]
+			return rest
+		}
+	}
+	return ""
+}
+
+func normalizeConnToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	parts := strings.Split(token, "_")
+	if len(parts) >= 4 {
+		// e.g., 699846_699846_curl_2457943216_1_0.0.0.0 -> keep first 4 to drop direction suffixes.
+		return strings.Join(parts[:4], "_")
+	}
+	return token
+}
+
+func extractStreamIdentifier(frame RawFrame) string {
+	for _, line := range frame.Lines {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "stream identifier") {
+			fields := strings.Fields(line)
+			for _, f := range fields {
+				f = strings.Trim(f, ":")
+				if strings.HasPrefix(f, "0x") || isAllDigits(f) {
+					if val, err := strconv.ParseInt(f, 0, 64); err == nil {
+						return strconv.FormatInt(val, 10)
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func isAllDigits(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
+}


### PR DESCRIPTION
In progress: add HTTPS text-mode capture via eCapture stdout, pair HTTP/2 requests and responses, and send witnesses with bodies.

What changed
- Added text-mode reader/parser for eCapture output (HTTP/2 HEADERS/DATA), builds ParsedRequest/Response with bodies and stable stream IDs.
- New collector buffers streams, emits akinet witnesses, optional debug dump via HTTPS_WITNESS_DEBUG_PATH.
- Daemonset wires ecapture binary launch (no pcap file path), new ssl scan helper; Dockerfile bundles ecapture.
- Added minikube test manifests (test HTTPS app curling GitHub/Google, daemonset for https-capture interface).

Known/remaining
- HTTP/1 pairing still TODO; currently focused on HTTP/2.
- UI occasionally misses some endpoints even though witness dump shows 200s (likely backend acceptance/filtering) — still investigating.
- README/docs kept local; not in this PR.