### PR TITLE
[AC-1132] Handle retry for k8s retriable errors

### DIFF
--- a/integrations/kube_apis/kube_apis.go
+++ b/integrations/kube_apis/kube_apis.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/postmanlabs/postman-insights-agent/printer"
 	coreV1 "k8s.io/api/core/v1"
-	kubeErrs "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -103,11 +102,7 @@ func (kc *KubeClient) initPodsEventsWatcher() error {
 			FieldSelector: fieldSelector,
 		})
 		if err != nil {
-			if kubeErrs.IsTimeout(err) {
-				printer.Warningf("request to get agent pod details timeout, retrying...")
-				return false, nil
-			}
-			return false, err
+			return backoffOnKubeAPIErr(err, "get agent pod details")
 		}
 		podsResourceVersion = pods.ResourceVersion
 		return true, nil
@@ -146,10 +141,7 @@ func (kc *KubeClient) GetPodsInAgentNode() ([]coreV1.Pod, error) {
 			FieldSelector: fieldSelector,
 		})
 		if err != nil {
-			if kubeErrs.IsTimeout(err) {
-				printer.Warningf("request to get pods in agent node timeout, retrying...")
-			}
-			return false, err
+			return backoffOnKubeAPIErr(err, "get pods in agent node")
 		}
 		pods = podList.Items
 		return true, nil

--- a/integrations/kube_apis/retry.go
+++ b/integrations/kube_apis/retry.go
@@ -1,0 +1,37 @@
+package kube_apis
+
+import (
+	"time"
+
+	"github.com/postmanlabs/postman-insights-agent/printer"
+	kubeErrs "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func isRetriableKubeErr(err error) bool {
+	return kubeErrs.IsTimeout(err) ||
+		kubeErrs.IsTooManyRequests(err) ||
+		kubeErrs.IsServerTimeout(err) ||
+		kubeErrs.IsServiceUnavailable(err) ||
+		kubeErrs.IsInternalError(err) ||
+		kubeErrs.IsUnexpectedServerError(err)
+}
+
+// backoffOnKubeAPIErr maps a Kubernetes API error to wait.ExponentialBackoff
+// condition return values. Retriable errors return (false, nil) so the backoff
+// loop continues; fatal errors return (false, err).
+func backoffOnKubeAPIErr(err error, operation string) (bool, error) {
+	if err == nil {
+		return false, nil
+	}
+	if !isRetriableKubeErr(err) {
+		return false, err
+	}
+
+	if sec, ok := kubeErrs.SuggestsClientDelay(err); ok && sec > 0 {
+		printer.Warningf("%s: server requested retry after %ds: %v\n", operation, sec, err)
+		time.Sleep(time.Duration(sec) * time.Second)
+	} else {
+		printer.Warningf("%s: retriable kube API error, retrying: %v\n", operation, err)
+	}
+	return false, nil
+}

--- a/integrations/kube_apis/retry_test.go
+++ b/integrations/kube_apis/retry_test.go
@@ -1,0 +1,81 @@
+package kube_apis
+
+import (
+	"errors"
+	"testing"
+
+	coreV1 "k8s.io/api/core/v1"
+	kubeErrs "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var podResource = coreV1.Resource("pods")
+
+func TestIsRetriableKubeErr(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "too many requests",
+			err:      kubeErrs.NewTooManyRequests("get pods", 5),
+			expected: true,
+		},
+		{
+			name:     "timeout",
+			err:      kubeErrs.NewTimeoutError("get pods", 0),
+			expected: true,
+		},
+		{
+			name:     "server timeout",
+			err:      kubeErrs.NewServerTimeout(podResource, "get", 10),
+			expected: true,
+		},
+		{
+			name:     "service unavailable",
+			err:      kubeErrs.NewServiceUnavailable("get pods"),
+			expected: true,
+		},
+		{
+			name:     "not found is fatal",
+			err:      kubeErrs.NewNotFound(podResource, "missing"),
+			expected: false,
+		},
+		{
+			name:     "forbidden is fatal",
+			err:      kubeErrs.NewForbidden(podResource, "get", errors.New("denied")),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRetriableKubeErr(tc.err); got != tc.expected {
+				t.Fatalf("isRetriableKubeErr() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBackoffOnKubeAPIErr(t *testing.T) {
+	t.Run("retriable error requests retry", func(t *testing.T) {
+		done, err := backoffOnKubeAPIErr(kubeErrs.NewTooManyRequests("get pods", 0), "get pods in agent node")
+		if done {
+			t.Fatal("expected done=false for retriable error")
+		}
+		if err != nil {
+			t.Fatalf("expected nil error for retriable error, got %v", err)
+		}
+	})
+
+	t.Run("fatal error is returned", func(t *testing.T) {
+		fatalErr := kubeErrs.NewForbidden(podResource, "get", errors.New("denied"))
+		done, err := backoffOnKubeAPIErr(fatalErr, "get pods in agent node")
+		if done {
+			t.Fatal("expected done=false for fatal error")
+		}
+		if !errors.Is(err, fatalErr) {
+			t.Fatalf("expected fatal error to be returned, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This pull request refactors and improves the retry logic for handling Kubernetes API errors in the `kube_apis` integration. The main change is the introduction of a centralized utility for classifying and handling retriable Kubernetes API errors, which simplifies error handling and makes the retry mechanism more robust and maintainable. Unit tests are also added to ensure correctness of the new logic.

**Centralized Kubernetes API error handling:**

* Added a new file `retry.go` containing `isRetriableKubeErr` and `backoffOnKubeAPIErr` helpers to centralize and standardize how retriable Kubernetes API errors are detected and handled, including support for server-suggested client delays.
* Updated error handling in `initPodsEventsWatcher` and `GetPodsInAgentNode` methods in `kube_apis.go` to use the new `backoffOnKubeAPIErr` function, replacing duplicated inline retry logic and removing the direct import of `kubeErrs` from those files.

**Testing improvements:**

* Added a new test file `retry_test.go` with comprehensive unit tests for both `isRetriableKubeErr` and `backoffOnKubeAPIErr` to verify correct classification and handling of different Kubernetes API errors.