### PR TITLE
[AC-1059] Follow-up changes in eBPF work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@ version: 2.1
 # Job graph
 # ---------
 #   build       — long-running Go build + unit tests (original; ~5 min)
-#   helm-smoke  — fast Helm lint + render validation (~30 s); added Phase 5c.3c
-#                 follow-up. Catches chart breakage BEFORE someone tries to
-#                 deploy a broken release. Scope: lint + render only. Full
-#                 kind cluster e2e remains a manual procedure documented in
-#                 docs/webhook-runbook.md (too expensive for every PR).
 jobs:
   build:
     working_directory: ~/repo
@@ -60,97 +55,7 @@ jobs:
       - store_test_results:
           path: /tmp/test-reports
 
-  helm-smoke:
-    working_directory: ~/repo
-    # Tiny base image — we just need bash + curl. Helm comes from its
-    # official tarball (no apt/brew dependency). Job runs in ~30 s.
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Check chart exists
-          command: |
-            if [ ! -d charts/postman-insights-webhook ]; then
-              echo "charts/postman-insights-webhook not present in this branch — skipping helm-smoke."
-              circleci-agent step halt
-            fi
-      - run:
-          name: Install Helm v3
-          command: |
-            curl -fsSL -o helm.tgz https://get.helm.sh/helm-v3.14.0-linux-amd64.tar.gz
-            tar xzf helm.tgz
-            sudo mv linux-amd64/helm /usr/local/bin/helm
-            helm version --short
-      - run:
-          name: helm lint
-          command: |
-            helm lint charts/postman-insights-webhook
-      - run:
-          name: helm template (tls.mode=secret — the default production path)
-          command: |
-            helm template release-test charts/postman-insights-webhook \
-                --namespace postman-insights \
-                --set image.tag=ci-smoke \
-                --set tls.secret.caBundle=BASE64CAHERE \
-                > /tmp/helm-secret.yaml
-            test -s /tmp/helm-secret.yaml
-            echo "→ rendered $(wc -l < /tmp/helm-secret.yaml) lines"
-            # Resource-kind sanity: must produce all four resources.
-            for kind in ServiceAccount Service Deployment MutatingWebhookConfiguration; do
-              grep -q "^kind: $kind\$" /tmp/helm-secret.yaml \
-                || (echo "MISSING $kind in rendered chart" && exit 1)
-            done
-            # Safety properties: failurePolicy MUST be Ignore at the
-            # webhook-config level. A future contributor flipping this
-            # to Fail without rehearsed rollback should be blocked here.
-            grep -q "failurePolicy: Ignore" /tmp/helm-secret.yaml \
-              || (echo "failurePolicy: Ignore is missing or changed!" && exit 1)
-            grep -q "sideEffects: None" /tmp/helm-secret.yaml \
-              || (echo "sideEffects: None is missing or changed!" && exit 1)
-            grep -q "timeoutSeconds: 5" /tmp/helm-secret.yaml \
-              || (echo "timeoutSeconds: 5 is missing or changed!" && exit 1)
-      - run:
-          name: helm template (tls.mode=cert-manager — the production-recommended path)
-          command: |
-            helm template release-test charts/postman-insights-webhook \
-                --namespace postman-insights \
-                --set image.tag=ci-smoke \
-                --set tls.mode=cert-manager \
-                --set tls.certManager.issuerRef.name=ci-issuer \
-                > /tmp/helm-cm.yaml
-            test -s /tmp/helm-cm.yaml
-            # cert-manager mode adds a Certificate resource AND the
-            # cert-manager.io/inject-ca-from annotation on the webhook config.
-            grep -q "^kind: Certificate\$" /tmp/helm-cm.yaml \
-              || (echo "Certificate resource missing in cert-manager mode" && exit 1)
-            grep -q "cert-manager.io/inject-ca-from" /tmp/helm-cm.yaml \
-              || (echo "cert-manager.io/inject-ca-from annotation missing" && exit 1)
-            # In cert-manager mode the caBundle is injected by cert-manager,
-            # so the chart MUST NOT inline a caBundle value.
-            if grep -E "^\s*caBundle:\s+[A-Za-z0-9+/=]+" /tmp/helm-cm.yaml ; then
-              echo "cert-manager mode unexpectedly inlined a caBundle"
-              exit 1
-            fi
-      - run:
-          name: helm template fail-fast (missing required value)
-          command: |
-            # In secret mode with NO caBundle override, helm template must
-            # FAIL with our 'required' message. This is the schema-typo guard.
-            if helm template release-test charts/postman-insights-webhook \
-                  --namespace postman-insights \
-                  --set image.tag=ci-smoke \
-                  > /tmp/helm-noca.yaml 2>/tmp/helm-noca.err ; then
-              echo "expected helm template to FAIL when caBundle is missing"
-              cat /tmp/helm-noca.yaml | head -20
-              exit 1
-            fi
-            grep -q "tls.secret.caBundle is required" /tmp/helm-noca.err \
-              || (echo "missing-required error message changed:" && cat /tmp/helm-noca.err && exit 1)
-            echo "→ fail-fast confirmed: missing caBundle is a clear template-time error"
-
 workflows:
   ci:
     jobs:
       - build
-      - helm-smoke

--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,3 @@ ebpf/loader/*.o
 test/kind/webhook/tls.crt
 test/kind/webhook/tls.key
 test/kind/webhook/webhook-deployment-with-certs.yaml
-
-# Generated certs from gen-test-certs.sh — created at runtime, do not commit.
-java-agent/testdata/hello-https/certs/*.p12
-java-agent/testdata/hello-https/certs/*.pem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  // eBPF loader sources use `//go:build linux && insights_bpf`. On macOS, gopls
+  // must cross-compile as Linux with the tag enabled to type-check those files.
+  "gopls": {
+    "buildFlags": ["-tags=insights_bpf"],
+    "env": {
+      "GOOS": "linux",
+      "GOARCH": "arm64"
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean build test mock dev-shell dev-build dev-down
+.PHONY: clean build test mock dev-shell dev-build dev-down docker-build docker-build-ebpf
 
 export GO111MODULE = on
 
@@ -29,6 +29,9 @@ endif
 
 docker-build:
 	docker build --target bin --output type=local,dest=bin,include=/postman-insights-agent --provenance false -f build-scripts/Dockerfile .
+
+docker-build-ebpf:
+	docker build --target bin --output type=local,dest=bin,include=/postman-insights-agent --provenance false -f build-scripts/Dockerfile.ebpf-bin .
 
 # --- Dev-container shortcuts for HTTPS-via-eBPF work on macOS. ---
 dev-build:

--- a/apidump/apidump.go
+++ b/apidump/apidump.go
@@ -135,10 +135,14 @@ type HTTPSCaptureArgs struct {
 	// limits how many bytes the BPF program copies from the SSL buffer into the
 	// ringbuf per SSL_read/SSL_write call, in kernel space. A single HTTPS body
 	// spans many such calls, so effective per-request coverage is higher.
-	// Defaults to 1024 (== MAX_EVENT_PAYLOAD in event.h), which is the size of
+	// Defaults to 4096 (== MAX_EVENT_PAYLOAD in event.h), which is the size of
 	// the fixed payload array in the ssl_event struct. The thermostat may lower
 	// this at runtime under CPU pressure.
 	BodySizeCap uint32
+
+	// DisableThermostat skips the CPU thermostat that lowers max_capture_bytes
+	// under load. Useful for e2e demos and debugging.
+	DisableThermostat bool
 
 	// CaptureMode is one of "headers" | "truncated" | "full". Phase 2 wires
 	// only "truncated" (the default, capped by BodySizeCap).

--- a/apidump/ebpf_integration.go
+++ b/apidump/ebpf_integration.go
@@ -158,11 +158,12 @@ func startHTTPSeBPFCapture(
 
 	bodyCap := args.HTTPS.BodySizeCap
 	if bodyCap == 0 {
-		bodyCap = 1024
+		bodyCap = 4096
 	}
 
 	ebpfArgs := ebpf.Defaults()
 	ebpfArgs.MaxCaptureBytes = bodyCap
+	ebpfArgs.DisableThermostat = args.HTTPS.DisableThermostat
 	ebpfArgs.EnforcePIDAllowlist = false
 	ebpfArgs.FactorySelector = selector
 	ebpfArgs.Out = out

--- a/build-scripts/Dockerfile.dev
+++ b/build-scripts/Dockerfile.dev
@@ -24,27 +24,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
         python3-requests \
         nodejs \
-        openjdk-17-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
-
-# Gradle for Phase 5b/5c Java agent work. Pinned for reproducibility; the
-# Java agent's `./gradlew` will lock it down further once a wrapper is in.
-ENV GRADLE_VERSION=8.7
-RUN curl -fsSL -o /tmp/gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    && unzip -q /tmp/gradle.zip -d /opt \
-    && ln -s /opt/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle \
-    && rm /tmp/gradle.zip
-
-# Standard JAVA_HOME so JNI headers resolve cleanly (jni.h ships under
-# $JAVA_HOME/include in OpenJDK). The -jdk-headless package installs to
-# /usr/lib/jvm/java-17-openjdk-${ARCH}/ but doesn't create the
-# default-java symlink, so we materialise it ourselves. This works on both
-# amd64 and arm64.
-RUN set -e; \
-    arch="$(dpkg --print-architecture)"; \
-    ln -sf "/usr/lib/jvm/java-17-openjdk-${arch}" /usr/lib/jvm/default-java
-ENV JAVA_HOME=/usr/lib/jvm/default-java
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # bpf2go used to materialize Go bindings from BPF C sources.
 RUN go install github.com/cilium/ebpf/cmd/bpf2go@v0.18.0

--- a/build-scripts/Dockerfile.ebpf
+++ b/build-scripts/Dockerfile.ebpf
@@ -1,7 +1,7 @@
 # eBPF-enabled build of postman-insights-agent.
 #
 # Produces a binary compiled with -tags insights_bpf so all eBPF paths
-# (HTTPS capture via SSL uprobes, Java TLS via kprobes) are included.
+# (HTTPS capture via SSL uprobes) are included.
 # Use this image for DaemonSet deployments that need --enable-https-capture.
 #
 # The standard build-scripts/Dockerfile builds WITHOUT eBPF (tags osusergo,netgo
@@ -56,16 +56,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libpcap0.8 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /out/postman-insights-agent /usr/local/bin/postman-insights-agent
-# Java agent JAR — used by the kube-webhook init container to seed the
-# shared volume for instrumented pods. Built on the host via
-# `cd java-agent && gradle shadowJar`; if missing the docker build fails fast.
-COPY java-agent/build/libs/postman-java-agent.jar /opt/postman-java-agent.jar
-# gRPC + combined REST/gRPC test workload (build:
-#   cd java-agent/testdata/grpc-java && gradle shadowJar)
-COPY java-agent/testdata/grpc-java/build/libs/grpc-java.jar /opt/grpc-java.jar
-# Minimal HTTPS test workload — JDK HttpsServer exercising the SSLEngine path.
-# (build: cd java-agent/testdata/hello-https && gradle --no-daemon shadowJar)
-COPY java-agent/testdata/hello-https/build/libs/hello-https.jar /opt/hello-https.jar
 # Requires privileged + CAP_BPF at runtime.
 # See modules/insights_agent_mns/main.tf for the full capability set.
 USER root

--- a/build-scripts/Dockerfile.ebpf-bin
+++ b/build-scripts/Dockerfile.ebpf-bin
@@ -1,0 +1,61 @@
+# Builds a Linux CLI binary with eBPF support (insights_bpf tag) and exports
+# it to the local bin/ directory via `make docker-build-ebpf`.
+#
+# Produces only the agent binary — no Java agent JARs or test workloads.
+# For a full deployment image (DaemonSet), use build-scripts/Dockerfile.ebpf.
+#
+# Uses Alpine + static linking (same approach as build-scripts/Dockerfile) so
+# the exported binary does not depend on libpcap.so at runtime.
+#
+# vmlinux.h: either commit a pre-generated copy under ebpf/programs/ (e.g.
+# from `make dev-shell` + bpftool), or build on a Linux host/CI runner where
+# /sys/kernel/btf/vmlinux is available and it will be generated at build time.
+
+FROM golang:1.25-alpine AS build
+
+# Alpine's libpcap does not include D-Bus support, so static linking with
+# -tags osusergo,netgo works cleanly without pulling in D-Bus.
+# Debian-based images compile libpcap with D-Bus, which causes unresolved
+# symbol errors when linking statically.
+RUN apk add --no-cache \
+        clang \
+        llvm \
+        bpftool \
+        libbpf-dev \
+        libpcap-dev \
+        gcc \
+        musl-dev \
+        linux-headers \
+        git \
+        ca-certificates
+
+RUN go install github.com/cilium/ebpf/cmd/bpf2go@v0.18.0
+ENV PATH="/root/go/bin:${PATH}"
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN if [ -f ebpf/programs/vmlinux.h ]; then \
+        echo "==> using pre-generated ebpf/programs/vmlinux.h"; \
+    elif [ -f /sys/kernel/btf/vmlinux ]; then \
+        echo "==> generating vmlinux.h from build host BTF"; \
+        bpftool btf dump file /sys/kernel/btf/vmlinux format c > ebpf/programs/vmlinux.h; \
+    else \
+        echo "ERROR: ebpf/programs/vmlinux.h missing and /sys/kernel/btf/vmlinux unavailable." >&2; \
+        echo "Generate it first, e.g. inside make dev-shell:" >&2; \
+        echo "  bpftool btf dump file /sys/kernel/btf/vmlinux format c > ebpf/programs/vmlinux.h" >&2; \
+        exit 1; \
+    fi
+
+RUN cd ebpf/loader && go generate -tags insights_bpf ./... && cd /src && \
+    go build -tags "insights_bpf,osusergo,netgo" \
+        -ldflags "-linkmode external -extldflags '-static'" \
+        -o /out/postman-insights-agent .
+
+FROM scratch AS bin
+
+COPY --from=build /out/postman-insights-agent /postman-insights-agent

--- a/cmd/internal/apidump-ebpf/run_linux.go
+++ b/cmd/internal/apidump-ebpf/run_linux.go
@@ -37,7 +37,7 @@ var (
 
 func init() {
 	Cmd.Flags().DurationVar(&flagDuration, "duration", 0, "Stop after this duration (0 = run until SIGINT)")
-	Cmd.Flags().Uint32Var(&flagMaxBytes, "max-capture-bytes", 1024, "Maximum plaintext bytes captured per event")
+	Cmd.Flags().Uint32Var(&flagMaxBytes, "max-capture-bytes", 4096, "Maximum plaintext bytes captured per event")
 	Cmd.Flags().Uint32Var(&flagRateCap, "rate-cap-per-sec", 0, "Per-PID rate cap (events/sec). 0 disables rate limiting.")
 	Cmd.Flags().DurationVar(&flagStatsEvery, "stats-every", 0, "If >0, log BPF counter stats every interval.")
 	Cmd.Flags().StringSliceVar(&flagTargetNamespaces, "target-namespaces", nil, "Restrict capture to PIDs whose K8s namespace is in this list. Requires running in a kube cluster.")
@@ -141,7 +141,7 @@ func runE(cmd *cobra.Command, _ []string) error {
 						rd, _ := ldr.ReadCounter(loader.CounterReadFailed)
 						rc, _ := ldr.ReadCounter(4) // rate-cap drops
 						by, _ := ldr.ReadCounter(loader.CounterBytesCaptured)
-						sf, _ := ldr.ReadCounter(5) // SSL_set_fd calls
+						sf, _ := ldr.ReadCounter(5)   // SSL_set_fd calls
 						fdok, _ := ldr.ReadCounter(6) // events with fd>=0
 						var resStats string
 						if a != nil && a.Resolver != nil {

--- a/cmd/internal/apidump/apidump.go
+++ b/cmd/internal/apidump/apidump.go
@@ -62,6 +62,7 @@ var (
 	httpsCBPFExcludePort  uint16
 	httpsRateCapPerSec    uint32
 	enableJavaTLS         bool
+	httpsNoThermostat     bool
 	privacyMode           string
 
 	commonApidumpFlags *CommonApidumpFlags
@@ -340,16 +341,17 @@ func apidumpRunInternal(_ *cobra.Command, _ []string) error {
 
 		// HTTPS-via-eBPF.
 		HTTPS: apidump.HTTPSCaptureArgs{
-			Enabled:          enableHTTPSCapture,
-			Libraries:        httpsLibraries,
-			TargetNamespaces: httpsTargetNamespaces,
-			BodySizeCap:      httpsBodySizeCap,
-			CaptureMode:      httpsCaptureMode,
-			CBPFExcludePort:  httpsCBPFExcludePort,
-			RateCapPerSec:    httpsRateCapPerSec,
-			EnableJavaTLS:    enableJavaTLS,
+			Enabled:           enableHTTPSCapture,
+			Libraries:         httpsLibraries,
+			TargetNamespaces:  httpsTargetNamespaces,
+			BodySizeCap:       httpsBodySizeCap,
+			CaptureMode:       httpsCaptureMode,
+			CBPFExcludePort:   httpsCBPFExcludePort,
+			RateCapPerSec:     httpsRateCapPerSec,
+			EnableJavaTLS:     enableJavaTLS,
+			DisableThermostat: httpsNoThermostat,
 		},
-		PrivacyMode:           privacyMode,
+		PrivacyMode: privacyMode,
 	}
 	if err := apidump.Run(args); err != nil {
 		return cmderr.AkitaErr{Err: err}
@@ -559,7 +561,7 @@ func init() {
 	Cmd.Flags().Uint32Var(
 		&httpsBodySizeCap,
 		"https-body-size-cap",
-		1024,
+		4096,
 		"Maximum plaintext bytes captured per SSL_read/SSL_write event. Larger bodies are truncated.",
 	)
 	Cmd.Flags().StringVar(
@@ -589,6 +591,12 @@ func init() {
 		"Also capture JVM TLS traffic via the java_tls kprobe (postman-java-agent ioctl bridge). "+
 			"Requires --enable-https-capture and postman-java-agent.jar injected into target JVMs "+
 			"(via the kube-webhook or JAVA_TOOL_OPTIONS manually).",
+	)
+	Cmd.Flags().BoolVar(
+		&httpsNoThermostat,
+		"no-thermostat",
+		false,
+		"Disable the CPU thermostat that lowers max-capture-bytes under load.",
 	)
 	Cmd.Flags().StringVar(
 		&privacyMode,

--- a/cmd/internal/kube/daemonset/apidump_process.go
+++ b/cmd/internal/kube/daemonset/apidump_process.go
@@ -119,7 +119,7 @@ func (d *Daemonset) StartApiDumpProcess(podUID types.UID) error {
 			WorkloadName:            podArgs.WorkloadName,
 			WorkloadType:            podArgs.WorkloadType,
 			Labels:                  podArgs.Labels,
-			HTTPS: buildHTTPSArgs(d, podArgs, netnsInode),
+			HTTPS:                   buildHTTPSArgs(d, podArgs, netnsInode),
 			DaemonsetArgs: optionals.Some(apidump.DaemonsetArgs{
 				TargetNetworkNamespaceOpt: networkNamespace,
 				StopChan:                  podArgs.StopChan,
@@ -161,6 +161,8 @@ func buildHTTPSArgs(d *Daemonset, podArgs *PodArgs, netnsInode uint64) apidump.H
 		ContainerNetnsInode: netnsInode,
 		RateCapPerSec:       d.HTTPSRateCapPerSec,
 		BodySizeCap:         d.HTTPSBodySizeCap,
+		CBPFExcludePort:     d.HTTPSCBPFExcludePort,
+		DisableThermostat:   d.HTTPSNoThermostat,
 		EnableJavaTLS:       d.EnableJavaTLS,
 	}
 

--- a/cmd/internal/kube/daemonset/daemonset.go
+++ b/cmd/internal/kube/daemonset/daemonset.go
@@ -41,9 +41,11 @@ type DaemonsetArgs struct {
 	// HTTPS capture via eBPF (uprobes on libssl).
 	// When true, each per-pod apidump.Run() starts an eBPF HTTPS capture
 	// pipeline alongside the pcap pipeline, scoped to the pod's namespace.
-	EnableHTTPSCapture  bool
-	HTTPSRateCapPerSec  uint32 // 0 = unlimited
-	HTTPSBodySizeCap    uint32 // 0 = default (1024 bytes)
+	EnableHTTPSCapture   bool
+	HTTPSRateCapPerSec   uint32 // 0 = unlimited
+	HTTPSBodySizeCap     uint32 // 0 = default (4096 bytes)
+	HTTPSCBPFExcludePort uint16 // 0 = no cBPF port exclusion; kube run defaults to 443
+	HTTPSNoThermostat    bool
 	// EnableJavaTLS also attaches the java_tls kprobe for JVM HTTPS traffic
 	// via the postman-java-agent ioctl bridge. Only effective when
 	// EnableHTTPSCapture is also true.
@@ -57,10 +59,12 @@ type Daemonset struct {
 	InsightsRateLimit        float64
 
 	// HTTPS capture config, propagated from DaemonsetArgs.
-	EnableHTTPSCapture bool
-	HTTPSRateCapPerSec uint32
-	HTTPSBodySizeCap   uint32
-	EnableJavaTLS      bool
+	EnableHTTPSCapture   bool
+	HTTPSRateCapPerSec   uint32
+	HTTPSBodySizeCap     uint32
+	HTTPSCBPFExcludePort uint16
+	HTTPSNoThermostat    bool
+	EnableJavaTLS        bool
 
 	KubeClient  kube_apis.KubeClient
 	CRIClient   *cri_apis.CriClient
@@ -231,6 +235,8 @@ func StartDaemonset(args DaemonsetArgs) error {
 		EnableHTTPSCapture:       args.EnableHTTPSCapture,
 		HTTPSRateCapPerSec:       args.HTTPSRateCapPerSec,
 		HTTPSBodySizeCap:         args.HTTPSBodySizeCap,
+		HTTPSCBPFExcludePort:     args.HTTPSCBPFExcludePort,
+		HTTPSNoThermostat:        args.HTTPSNoThermostat,
 		EnableJavaTLS:            args.EnableJavaTLS,
 	}
 

--- a/cmd/internal/kube/daemonset/https_test.go
+++ b/cmd/internal/kube/daemonset/https_test.go
@@ -39,9 +39,10 @@ func TestBuildHTTPSArgs_InodeTakesPriority(t *testing.T) {
 	// TargetNamespaces must NOT be set — even if the pod has a namespace.
 	// This is the normal DaemonSet path for any scaled deployment.
 	d := &Daemonset{
-		EnableHTTPSCapture: true,
-		HTTPSRateCapPerSec: 500,
-		HTTPSBodySizeCap:   2048,
+		EnableHTTPSCapture:   true,
+		HTTPSRateCapPerSec:   500,
+		HTTPSBodySizeCap:     2048,
+		HTTPSCBPFExcludePort: 443,
 	}
 	pod := &PodArgs{Namespace: "team-a"}
 	const inode uint64 = 99991
@@ -55,6 +56,7 @@ func TestBuildHTTPSArgs_InodeTakesPriority(t *testing.T) {
 		"TargetNamespaces must be nil when inode is available — inode path is pod-level")
 	assert.Equal(t, uint32(500), got.RateCapPerSec)
 	assert.Equal(t, uint32(2048), got.BodySizeCap)
+	assert.Equal(t, uint16(443), got.CBPFExcludePort)
 }
 
 func TestBuildHTTPSArgs_InodeZeroWithNamespace_FallsBackToNamespace(t *testing.T) {
@@ -125,6 +127,28 @@ func TestBuildHTTPSArgs_RateAndBodyPropagation(t *testing.T) {
 	}
 }
 
+func TestBuildHTTPSArgs_CBPFExcludePortPropagation(t *testing.T) {
+	tests := []struct {
+		name        string
+		excludePort uint16
+		wantExclude uint16
+	}{
+		{"default 443", 443, 443},
+		{"custom 8443", 8443, 8443},
+		{"zero disables exclusion", 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Daemonset{
+				EnableHTTPSCapture:   true,
+				HTTPSCBPFExcludePort: tt.excludePort,
+			}
+			got := buildHTTPSArgs(d, &PodArgs{}, 42)
+			assert.Equal(t, tt.wantExclude, got.CBPFExcludePort)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DaemonsetArgs — HTTPS field zero values and propagation
 // ---------------------------------------------------------------------------
@@ -165,21 +189,24 @@ func TestDaemonset_HTTPSFieldsPropagatedFromArgs(t *testing.T) {
 	// inspecting the struct directly to catch regressions without standing up
 	// the full daemonset).
 	args := DaemonsetArgs{
-		EnableHTTPSCapture: true,
-		HTTPSRateCapPerSec: 123,
-		HTTPSBodySizeCap:   456,
+		EnableHTTPSCapture:   true,
+		HTTPSRateCapPerSec:   123,
+		HTTPSBodySizeCap:     456,
+		HTTPSCBPFExcludePort: 443,
 	}
 
 	// Simulate the assignment done by StartDaemonset.
 	d := &Daemonset{
-		EnableHTTPSCapture: args.EnableHTTPSCapture,
-		HTTPSRateCapPerSec: args.HTTPSRateCapPerSec,
-		HTTPSBodySizeCap:   args.HTTPSBodySizeCap,
+		EnableHTTPSCapture:   args.EnableHTTPSCapture,
+		HTTPSRateCapPerSec:   args.HTTPSRateCapPerSec,
+		HTTPSBodySizeCap:     args.HTTPSBodySizeCap,
+		HTTPSCBPFExcludePort: args.HTTPSCBPFExcludePort,
 	}
 
 	assert.True(t, d.EnableHTTPSCapture)
 	assert.Equal(t, uint32(123), d.HTTPSRateCapPerSec)
 	assert.Equal(t, uint32(456), d.HTTPSBodySizeCap)
+	assert.Equal(t, uint16(443), d.HTTPSCBPFExcludePort)
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/internal/kube/run.go
+++ b/cmd/internal/kube/run.go
@@ -16,23 +16,27 @@ var (
 	excludeLabels     map[string]string
 
 	// HTTPS capture via eBPF uprobes on libssl.
-	enableHTTPSCapture bool
-	httpsRateCapPerSec uint32
-	httpsBodySizeCap   uint32
+	enableHTTPSCapture   bool
+	httpsRateCapPerSec   uint32
+	httpsBodySizeCap     uint32
+	httpsCBPFExcludePort uint16
+	httpsNoThermostat    bool
 )
 
 func StartDaemonsetAndHibernateOnError(_ *cobra.Command, args []string) error {
 	err := daemonset.StartDaemonset(daemonset.DaemonsetArgs{
-		ReproMode:          reproMode,
-		RateLimit:          rateLimit,
-		DiscoveryMode:      discoveryMode,
-		IncludeNamespaces:  includeNamespaces,
-		ExcludeNamespaces:  excludeNamespaces,
-		IncludeLabels:      includeLabels,
-		ExcludeLabels:      excludeLabels,
-		EnableHTTPSCapture: enableHTTPSCapture,
-		HTTPSRateCapPerSec: httpsRateCapPerSec,
-		HTTPSBodySizeCap:   httpsBodySizeCap,
+		ReproMode:            reproMode,
+		RateLimit:            rateLimit,
+		DiscoveryMode:        discoveryMode,
+		IncludeNamespaces:    includeNamespaces,
+		ExcludeNamespaces:    excludeNamespaces,
+		IncludeLabels:        includeLabels,
+		ExcludeLabels:        excludeLabels,
+		EnableHTTPSCapture:   enableHTTPSCapture,
+		HTTPSRateCapPerSec:   httpsRateCapPerSec,
+		HTTPSBodySizeCap:     httpsBodySizeCap,
+		HTTPSCBPFExcludePort: httpsCBPFExcludePort,
+		HTTPSNoThermostat:    httpsNoThermostat,
 	})
 	if err == nil {
 		return nil
@@ -116,7 +120,20 @@ func init() {
 		&httpsBodySizeCap,
 		"https-body-size-cap",
 		0,
-		"Maximum bytes captured per HTTPS payload (0 = default 1024).",
+		"Maximum bytes captured per HTTPS payload (0 = default 4096).",
+	)
+	runCmd.PersistentFlags().BoolVar(
+		&httpsNoThermostat,
+		"no-thermostat",
+		false,
+		"Disable the CPU thermostat that lowers max-capture-bytes under load.",
+	)
+	runCmd.PersistentFlags().Uint16Var(
+		&httpsCBPFExcludePort,
+		"https-cbpf-exclude-port",
+		443,
+		"TCP port whose packets are removed from the cBPF filter when --enable-https-capture is set. "+
+			"Avoids double-counting TLS handshake bytes already captured via eBPF. 0 disables exclusion.",
 	)
 
 	Cmd.AddCommand(runCmd)

--- a/ebpf/collect_linux.go
+++ b/ebpf/collect_linux.go
@@ -75,7 +75,7 @@ type Args struct {
 // Defaults returns sensible default Args for production use.
 func Defaults() Args {
 	return Args{
-		MaxCaptureBytes:     1024,
+		MaxCaptureBytes:     4096,
 		EnforcePIDAllowlist: false,
 		DiscoveryInterval:   5 * time.Second,
 		FlowIdleTimeout:     30 * time.Second,

--- a/ebpf/collect_stub.go
+++ b/ebpf/collect_stub.go
@@ -19,7 +19,7 @@ import (
 // to *ebpf.Thermostat in their telemetry plumbing.
 type Thermostat struct{}
 
-func (*Thermostat) CurrentCap() uint32   { return 0 }
+func (*Thermostat) CurrentCap() uint32  { return 0 }
 func (*Thermostat) CPUPercent() float64 { return 0 }
 
 // Args is the platform-neutral declaration so callers can construct it
@@ -41,7 +41,7 @@ type Args struct {
 
 func Defaults() Args {
 	return Args{
-		MaxCaptureBytes:   1024,
+		MaxCaptureBytes:   4096,
 		DiscoveryInterval: 5 * time.Second,
 		FlowIdleTimeout:   30 * time.Second,
 	}
@@ -58,13 +58,13 @@ func NewJavaTLSCollector(_ uint32, _ bool, _ *events.Adapter) (*JavaTLSCollector
 	return nil, ErrUnsupported
 }
 
-func (c *JavaTLSCollector) Attach() error                              { return ErrUnsupported }
-func (c *JavaTLSCollector) Run(_ context.Context, _ time.Time)        {}
-func (c *JavaTLSCollector) Close() error                              { return nil }
-func (c *JavaTLSCollector) AddTargetPID(_ uint32) error               { return nil }
-func (c *JavaTLSCollector) RemoveTargetPID(_ uint32) error            { return nil }
-func (c *JavaTLSCollector) CounterEmitted() uint64                    { return 0 }
-func (c *JavaTLSCollector) CounterRingbufDrops() uint64               { return 0 }
-func (c *JavaTLSCollector) CounterReadFailed() uint64                 { return 0 }
-func (c *JavaTLSCollector) CounterBytes() uint64                      { return 0 }
-func (c *JavaTLSCollector) CounterBadCmd() uint64                     { return 0 }
+func (c *JavaTLSCollector) Attach() error                      { return ErrUnsupported }
+func (c *JavaTLSCollector) Run(_ context.Context, _ time.Time) {}
+func (c *JavaTLSCollector) Close() error                       { return nil }
+func (c *JavaTLSCollector) AddTargetPID(_ uint32) error        { return nil }
+func (c *JavaTLSCollector) RemoveTargetPID(_ uint32) error     { return nil }
+func (c *JavaTLSCollector) CounterEmitted() uint64             { return 0 }
+func (c *JavaTLSCollector) CounterRingbufDrops() uint64        { return 0 }
+func (c *JavaTLSCollector) CounterReadFailed() uint64          { return 0 }
+func (c *JavaTLSCollector) CounterBytes() uint64               { return 0 }
+func (c *JavaTLSCollector) CounterBadCmd() uint64              { return 0 }

--- a/ebpf/events/adapter.go
+++ b/ebpf/events/adapter.go
@@ -18,7 +18,7 @@ import (
 // a malformed or pathological stream that never produces a parseable HTTP
 // message could grow unbounded. The value mirrors OBI's `large_buffers`
 // limit at the user-space side.
-const MaxPendingPerFlow = 64 * 1024
+const MaxPendingPerFlow = 1 * 1024 * 1024
 
 // Adapter feeds decrypted-byte events from a Reader into the existing akinet
 // HTTP/HTTP2 parsers, producing akinet.ParsedNetworkTraffic records that are
@@ -26,17 +26,17 @@ const MaxPendingPerFlow = 64 * 1024
 //
 // Per-flow state machine:
 //
-//   For each FlowKey (PID, SSLCtx, Direction):
-//     - Incoming bytes are appended to a per-flow pending buffer.
-//     - With no current parser: consult the FactorySelector.
-//         Accept       → create parser, hand pending bytes to Parse.
-//         NeedMoreData → keep pending bytes, return.
-//         Reject       → drop the flow permanently.
-//     - With a current parser: call Parse(pending, false). On a non-nil
-//       result, emit a ParsedNetworkTraffic on Out, clear the parser, and
-//       re-enter the "no parser" branch with any unused tail bytes (this
-//       handles HTTP keep-alive pipelining: one TCP/SSL flow carrying
-//       N back-to-back requests or responses).
+//	For each FlowKey (PID, SSLCtx, Direction):
+//	  - Incoming bytes are appended to a per-flow pending buffer.
+//	  - With no current parser: consult the FactorySelector.
+//	      Accept       → create parser, hand pending bytes to Parse.
+//	      NeedMoreData → keep pending bytes, return.
+//	      Reject       → drop the flow permanently.
+//	  - With a current parser: call Parse(pending, false). On a non-nil
+//	    result, emit a ParsedNetworkTraffic on Out, clear the parser, and
+//	    re-enter the "no parser" branch with any unused tail bytes (this
+//	    handles HTTP keep-alive pipelining: one TCP/SSL flow carrying
+//	    N back-to-back requests or responses).
 //
 // The flow is forgotten after a configurable idle timeout (default 30s) or
 // when an SSL_shutdown event arrives.

--- a/ebpf/events/adapter.go
+++ b/ebpf/events/adapter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/akitasoftware/akita-libs/akinet"
 	"github.com/akitasoftware/akita-libs/memview"
+	"github.com/google/gopacket/reassembly"
 	"github.com/google/uuid"
 )
 
@@ -61,10 +62,12 @@ type Adapter struct {
 	mu    sync.Mutex
 	flows map[FlowKey]*flowState
 
-	// resolved caches socket tuples by (pid, ssl_ctx) so the ingress and
-	// egress sides of the same TLS connection share one /proc lookup, and
-	// so a successful early-event resolve survives even after the socket
-	// has been closed.
+	// conns holds per-TLS-connection state shared by ingress and egress
+	// FlowKeys with the same (PID, SSLCtx). Mirrors pcap's single bidiID per
+	// TCP connection in tcpStream.
+	conns map[connKey]*tlsConnState
+
+	// resolved caches socket tuples by (pid, ssl_ctx, fd).
 	resolved map[resolvedKey]SocketInfo
 
 	// Counters exported for telemetry / tests.
@@ -72,11 +75,57 @@ type Adapter struct {
 	FlowsDropped    uint64
 }
 
+// connKey identifies a TLS connection (both directions).
+type connKey struct {
+	PID    uint32
+	SSLCtx uint64
+}
+
+// tlsConnState is shared by all FlowKeys on the same TLS connection.
+type tlsConnState struct {
+	bidiID akinet.TCPBidiID
+
+	// Synthetic pair indices substitute for TCP seq/ack in the akihttp
+	// parser (request Seq = ack, response Seq = seq). Requests push their
+	// index onto unmatchedRequests; responses pop FIFO so pipelined HTTP/1.1
+	// still pairs correctly.
+	nextPairIdx       int
+	unmatchedRequests []int
+	activeFlowCount   int
+
+	// Resolved 4-tuple shared by ingress and egress on this TLS connection.
+	socketResolved bool
+	localIP        net.IP
+	localPort      int
+	remoteIP       net.IP
+	remotePort     int
+}
+
+func (c *tlsConnState) pairSeqForFactory(factory akinet.TCPParserFactory) reassembly.Sequence {
+	if isHTTPRequestParserFactory(factory) {
+		idx := c.nextPairIdx
+		c.nextPairIdx++
+		c.unmatchedRequests = append(c.unmatchedRequests, idx)
+		return reassembly.Sequence(idx)
+	}
+	idx := c.nextPairIdx
+	if len(c.unmatchedRequests) > 0 {
+		idx = c.unmatchedRequests[0]
+		c.unmatchedRequests = c.unmatchedRequests[1:]
+	} else {
+		c.nextPairIdx++
+	}
+	return reassembly.Sequence(idx)
+}
+
+func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
+	return factory.Name() == "HTTP/1.x Request Parser Factory"
+}
+
 type flowState struct {
 	parser    akinet.TCPParser
 	pending   memview.MemView
-	bidiID    akinet.TCPBidiID
-	msgSeq    int
+	conn      *tlsConnState
 	firstSeen time.Time
 	lastSeen  time.Time
 	totalIn   int  // total bytes ever observed on this flow
@@ -88,14 +137,7 @@ type flowState struct {
 	// Detection happens on the first bytes via IsHTTP2Preface.
 	h2 *h2State
 
-	// Resolved (or cached) socket info for this flow. Resolved on first
-	// event with a valid fd; reused for the lifetime of the flow.
-	socketResolved bool
-	localIP        net.IP
-	localPort      int
-	remoteIP       net.IP
-	remotePort     int
-	pid            uint32 // for Forget on flow close
+	pid uint32 // for Forget on flow close
 }
 
 // resolvedKey includes fd because nginx (and other servers) maintain SSL*
@@ -114,7 +156,8 @@ func NewAdapter(fs akinet.TCPParserFactorySelector, out chan<- akinet.ParsedNetw
 		FactorySelector: fs,
 		Out:             out,
 		flows:           make(map[FlowKey]*flowState),
-		resolved:        make(map[resolvedKey]SocketInfo),
+		conns:    make(map[connKey]*tlsConnState),
+		resolved: make(map[resolvedKey]SocketInfo),
 	}
 }
 
@@ -127,44 +170,30 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 	defer a.mu.Unlock()
 
 	key := ev.Key()
+	ck := connKey{PID: ev.PID, SSLCtx: ev.SSLCtx}
+	conn := a.conns[ck]
+	if conn == nil {
+		conn = &tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())}
+		a.conns[ck] = conn
+	}
+
 	st := a.flows[key]
 	if st == nil {
 		st = &flowState{
 			firstSeen: ev.Time(monoEpoch),
-			bidiID:    akinet.TCPBidiID(uuid.New()),
+			conn:      conn,
 			ifaceTag:  fmt.Sprintf("ebpf-pid-%d", ev.PID),
 			pid:       ev.PID,
 		}
 		a.flows[key] = st
+		conn.activeFlowCount++
 	}
 	if st.dropped {
 		return
 	}
 
-	// Lazily resolve the 4-tuple from (pid, fd). On success we cache by
-	// (pid, ssl_ctx, fd) — fd is needed because SSL* pointers are reused
-	// across distinct TCP connections by servers with connection pools.
-	// Same (pid, ssl_ctx, fd) means same actual connection and the tuple
-	// is safe to share between ingress and egress and between events whose
-	// fd has been reclaimed.
-	if !st.socketResolved && a.Resolver != nil && ev.FD >= 0 {
-		rk := resolvedKey{PID: ev.PID, SSLCtx: ev.SSLCtx, FD: ev.FD}
-		if info, ok := a.resolved[rk]; ok {
-			st.localIP = info.LocalIP
-			st.localPort = info.LocalPort
-			st.remoteIP = info.RemoteIP
-			st.remotePort = info.RemotePort
-			st.socketResolved = true
-		} else if info, err := a.Resolver.Resolve(ev.PID, ev.FD); err == nil {
-			a.resolved[rk] = info
-			st.localIP = info.LocalIP
-			st.localPort = info.LocalPort
-			st.remoteIP = info.RemoteIP
-			st.remotePort = info.RemotePort
-			st.socketResolved = true
-		}
-		// Failed lookups are non-fatal; we'll retry on the next event.
-	}
+	// Lazily resolve the 4-tuple from (pid, fd) when available.
+	a.tryResolveConn(conn, ev)
 	st.lastSeen = ev.Time(monoEpoch)
 	st.totalIn += int(ev.LenCaptured)
 
@@ -182,7 +211,7 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 	// the common case for gotls because the TLS handshake + preface complete
 	// before the uprobes catch their first non-handshake call).
 	if st.pending.Len() == 0 && (IsHTTP2Preface(ev.Bytes()) || IsHTTP2Frame(ev.Bytes())) {
-		st.h2 = newH2State(st.ifaceTag)
+		st.h2 = newH2State(st.conn.bidiID)
 		for _, pnt := range st.h2.feed(ev.Bytes(), ev.Time(monoEpoch), st.ifaceTag) {
 			a.emitH2PNT(key, st, pnt)
 		}
@@ -215,11 +244,10 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 				}
 				return
 			case akinet.Accept:
-				// initialSeq/initialAck are zero — we don't have TCP seq numbers
-				// in the eBPF path, and the akihttp parser doesn't depend on
-				// them for correctness, only for cross-pcap reassembly pairing
-				// (which doesn't apply here: our bidiID is synthetic).
-				st.parser = factory.CreateParser(st.bidiID, 0, 0)
+				// Synthetic seq/ack mirror pcap: request PairKey uses ack,
+				// response PairKey uses seq, both equal to the same pair index.
+				pairSeq := st.conn.pairSeqForFactory(factory)
+				st.parser = factory.CreateParser(st.conn.bidiID, pairSeq, pairSeq)
 			}
 		}
 
@@ -239,24 +267,23 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 		// Got a complete message. Emit it and continue with unused tail.
 		a.Out <- a.toPNT(st, key, result, now)
 		a.MessagesEmitted++
-		st.msgSeq++
 		st.parser = nil
 		st.pending = unused
 	}
 }
 
 func (a *Adapter) emitH2PNT(key FlowKey, st *flowState, pnt akinet.ParsedNetworkTraffic) {
-	if st.socketResolved {
+	if st.conn.socketResolved {
 		if key.Direction == DirEgress {
-			pnt.SrcIP, pnt.SrcPort = st.localIP, st.localPort
-			pnt.DstIP, pnt.DstPort = st.remoteIP, st.remotePort
+			pnt.SrcIP, pnt.SrcPort = st.conn.localIP, st.conn.localPort
+			pnt.DstIP, pnt.DstPort = st.conn.remoteIP, st.conn.remotePort
 		} else {
-			pnt.SrcIP, pnt.SrcPort = st.remoteIP, st.remotePort
-			pnt.DstIP, pnt.DstPort = st.localIP, st.localPort
+			pnt.SrcIP, pnt.SrcPort = st.conn.remoteIP, st.conn.remotePort
+			pnt.DstIP, pnt.DstPort = st.conn.localIP, st.conn.localPort
 		}
 	}
 	if req, ok := pnt.Content.(akinet.HTTPRequest); ok {
-		enrichHTTPRequestURL(&req, key.Direction, st.localIP, st.localPort, st.remoteIP, st.remotePort)
+		enrichHTTPRequestURL(&req, key.Direction, st.conn.localIP, st.conn.localPort, st.conn.remoteIP, st.conn.remotePort)
 		pnt.Content = req
 	}
 	a.Out <- pnt
@@ -288,17 +315,17 @@ func (a *Adapter) toPNT(st *flowState, key FlowKey, c akinet.ParsedNetworkConten
 		ObservationTime: st.firstSeen,
 		FinalPacketTime: now,
 	}
-	if st.socketResolved {
+	if st.conn.socketResolved {
 		if key.Direction == DirEgress {
-			pnt.SrcIP = st.localIP
-			pnt.SrcPort = st.localPort
-			pnt.DstIP = st.remoteIP
-			pnt.DstPort = st.remotePort
+			pnt.SrcIP = st.conn.localIP
+			pnt.SrcPort = st.conn.localPort
+			pnt.DstIP = st.conn.remoteIP
+			pnt.DstPort = st.conn.remotePort
 		} else {
-			pnt.SrcIP = st.remoteIP
-			pnt.SrcPort = st.remotePort
-			pnt.DstIP = st.localIP
-			pnt.DstPort = st.localPort
+			pnt.SrcIP = st.conn.remoteIP
+			pnt.SrcPort = st.conn.remotePort
+			pnt.DstIP = st.conn.localIP
+			pnt.DstPort = st.conn.localPort
 		}
 	} else {
 		pnt.SrcIP = net.IPv4zero
@@ -315,11 +342,19 @@ func (a *Adapter) GC(now time.Time, maxIdle time.Duration) int {
 	dropped := 0
 	for k, st := range a.flows {
 		if now.Sub(st.lastSeen) > maxIdle {
-			delete(a.flows, k)
+			a.forgetFlow(k, st)
 			dropped++
 		}
 	}
 	return dropped
+}
+
+func (a *Adapter) forgetFlow(key FlowKey, st *flowState) {
+	delete(a.flows, key)
+	st.conn.activeFlowCount--
+	if st.conn.activeFlowCount == 0 {
+		delete(a.conns, connKey{PID: key.PID, SSLCtx: key.SSLCtx})
+	}
 }
 
 // CloseFlow forgets state for one flow. Called when an SSL_shutdown event
@@ -327,7 +362,9 @@ func (a *Adapter) GC(now time.Time, maxIdle time.Duration) int {
 func (a *Adapter) CloseFlow(key FlowKey) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	delete(a.flows, key)
+	if st, ok := a.flows[key]; ok {
+		a.forgetFlow(key, st)
+	}
 }
 
 // Snapshot returns counts for telemetry.
@@ -347,7 +384,33 @@ func (a *Adapter) Snapshot() (numFlows int, totalBytes int) {
 func (a *Adapter) PreResolve(pid uint32, sslCtx uint64, fd int32, info SocketInfo) {
 	a.mu.Lock()
 	a.resolved[resolvedKey{PID: pid, SSLCtx: sslCtx, FD: fd}] = info
+	if conn, ok := a.conns[connKey{PID: pid, SSLCtx: sslCtx}]; ok {
+		a.applySocketInfo(conn, info)
+	}
 	a.mu.Unlock()
+}
+
+func (a *Adapter) tryResolveConn(conn *tlsConnState, ev *SSLEvent) {
+	if conn.socketResolved || a.Resolver == nil || ev.FD < 0 {
+		return
+	}
+	rk := resolvedKey{PID: ev.PID, SSLCtx: ev.SSLCtx, FD: ev.FD}
+	if info, ok := a.resolved[rk]; ok {
+		a.applySocketInfo(conn, info)
+		return
+	}
+	if info, err := a.Resolver.Resolve(ev.PID, ev.FD); err == nil {
+		a.resolved[rk] = info
+		a.applySocketInfo(conn, info)
+	}
+}
+
+func (a *Adapter) applySocketInfo(conn *tlsConnState, info SocketInfo) {
+	conn.localIP = info.LocalIP
+	conn.localPort = info.LocalPort
+	conn.remoteIP = info.RemoteIP
+	conn.remotePort = info.RemotePort
+	conn.socketResolved = true
 }
 
 // ForgetResolved drops cached resolutions for a PID (on PID exit).

--- a/ebpf/events/adapter_test.go
+++ b/ebpf/events/adapter_test.go
@@ -131,6 +131,63 @@ loop:
 	if got[1].Method != "POST" || got[1].URL.Path != "/b" {
 		t.Errorf("second: %s %s", got[1].Method, got[1].URL)
 	}
+	if got[0].Seq == got[1].Seq {
+		t.Errorf("pipelined requests should have distinct pair indices, both Seq=%d", got[0].Seq)
+	}
+}
+
+// Ingress request + egress response on the same TLS connection share StreamID
+// and Seq so BackendCollector can pair them (mirrors pcap tcpStream.bidiID).
+func TestAdapter_RequestResponsePairing(t *testing.T) {
+	a, out := newTestAdapter(t)
+	const pid uint32 = 52837
+	const sslCtx uint64 = 0xDEADBEEF
+
+	req := []byte("GET / HTTP/1.1\r\nHost: example.com\r\nAccept: */*\r\n\r\n")
+	resp := []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+
+	feed(t, a, pid, sslCtx, DirIngress, req)
+	feed(t, a, pid, sslCtx, DirEgress, resp)
+
+	var reqContent akinet.HTTPRequest
+	var respContent akinet.HTTPResponse
+	for i := 0; i < 2; i++ {
+		pnt := <-out
+		switch c := pnt.Content.(type) {
+		case akinet.HTTPRequest:
+			reqContent = c
+		case akinet.HTTPResponse:
+			respContent = c
+		}
+	}
+
+	if reqContent.StreamID != respContent.StreamID {
+		t.Fatalf("StreamID mismatch: req=%v resp=%v", reqContent.StreamID, respContent.StreamID)
+	}
+	if reqContent.Seq != respContent.Seq {
+		t.Fatalf("Seq mismatch: req=%d resp=%d", reqContent.Seq, respContent.Seq)
+	}
+}
+
+// Repeated GET / on keep-alive must not reuse the same pair index.
+func TestAdapter_KeepAliveDistinctPairKeys(t *testing.T) {
+	a, out := newTestAdapter(t)
+	const pid uint32 = 52837
+	const sslCtx uint64 = 0xDEADBEEF
+
+	req := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	feed(t, a, pid, sslCtx, DirIngress, req)
+	first := (<-out).Content.(akinet.HTTPRequest)
+
+	feed(t, a, pid, sslCtx, DirIngress, req)
+	second := (<-out).Content.(akinet.HTTPRequest)
+
+	if first.StreamID != second.StreamID {
+		t.Fatalf("keep-alive requests should share StreamID")
+	}
+	if first.Seq == second.Seq {
+		t.Fatalf("keep-alive requests must not collide on Seq: both %d", first.Seq)
+	}
 }
 
 // GET requests with query strings must preserve RawQuery through the adapter.

--- a/ebpf/events/event.go
+++ b/ebpf/events/event.go
@@ -10,9 +10,9 @@ const (
 	DirIngress uint8 = 1 // local process is receiving (SSL_read)
 )
 
-// MaxEventPayload mirrors MAX_EVENT_PAYLOAD in event.h. Used to size the
+// MaxEventPayload mirrors MAX_EVENT_PAYLOAD in event.h (4096). Used to size the
 // payload byte array when decoding ringbuf records.
-const MaxEventPayload = 1024
+const MaxEventPayload = 4096
 
 // SSLEvent is the Go form of `struct ssl_event` emitted by libssl.bpf.c.
 //

--- a/ebpf/events/http2.go
+++ b/ebpf/events/http2.go
@@ -148,12 +148,11 @@ type h2Stream struct {
 // adapter's MaxPendingPerFlow.
 const h2MaxBodyBytes = 1 * 1024 * 1024
 
-func newH2State(interfaceTag string) *h2State {
-	_ = interfaceTag // reserved
+func newH2State(bidiID akinet.TCPBidiID) *h2State {
 	return &h2State{
 		hpack:   hpack.NewDecoder(4096, nil),
 		streams: map[uint32]*h2Stream{},
-		bidiID:  akinet.TCPBidiID(uuid.New()),
+		bidiID:  bidiID,
 	}
 }
 

--- a/ebpf/events/http2.go
+++ b/ebpf/events/http2.go
@@ -91,8 +91,8 @@ type h2State struct {
 	// In-progress HEADERS+CONTINUATION sequence: HPACK requires CONTINUATION
 	// frames to be feed contiguously to the decoder. We accumulate the
 	// header block fragment bytes here until END_HEADERS is set.
-	headerBlock     []byte
-	headersStreamID uint32
+	headerBlock      []byte
+	headersStreamID  uint32
 	headersEndStream bool
 
 	// Per-stream state, keyed by stream ID.
@@ -146,7 +146,7 @@ type h2Stream struct {
 
 // h2MaxBodyBytes bounds the body bytes we'll buffer per stream. Mirrors
 // adapter's MaxPendingPerFlow.
-const h2MaxBodyBytes = 64 * 1024
+const h2MaxBodyBytes = 1 * 1024 * 1024
 
 func newH2State(interfaceTag string) *h2State {
 	_ = interfaceTag // reserved
@@ -183,7 +183,8 @@ func IsHTTP2Preface(b []byte) bool {
 // read/write).
 //
 // An HTTP/2 frame header (RFC 7540 §4.1) is 9 bytes:
-//   length(3) | type(1) | flags(1) | R+streamID(4, top bit reserved=0)
+//
+//	length(3) | type(1) | flags(1) | R+streamID(4, top bit reserved=0)
 //
 // We require:
 //   - at least 9 bytes,

--- a/ebpf/events/http2_test.go
+++ b/ebpf/events/http2_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/akitasoftware/akita-libs/akinet"
+	"github.com/google/uuid"
 	"golang.org/x/net/http2/hpack"
 )
 
@@ -63,7 +64,7 @@ func buildDataFrame(streamID uint32, endStream bool, body []byte) []byte {
 
 // TestH2_RequestNoBody — HEADERS with END_STREAM emits an HTTPRequest.
 func TestH2_RequestNoBody(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/users/42"},
@@ -95,7 +96,7 @@ func TestH2_RequestNoBody(t *testing.T) {
 
 // TestH2_RequestWithBody — HEADERS + DATA(END_STREAM) → HTTPRequest with body.
 func TestH2_RequestWithBody(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	headers := buildHeadersFrame(t, 3, false, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},
 		{Name: ":path", Value: "/echo"},
@@ -119,7 +120,7 @@ func TestH2_RequestWithBody(t *testing.T) {
 
 // TestH2_Response — :status pseudo-header yields an HTTPResponse.
 func TestH2_Response(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":status", Value: "204"},
 		{Name: "content-length", Value: "0"},
@@ -139,7 +140,7 @@ func TestH2_Response(t *testing.T) {
 
 // TestH2_Preface — preface is stripped before frame parsing.
 func TestH2_Preface(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/"},
@@ -153,7 +154,7 @@ func TestH2_Preface(t *testing.T) {
 
 // TestH2_MultipleStreams — interleaved frames on two streams produce two PNTs.
 func TestH2_MultipleStreams(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	h1 := buildHeadersFrame(t, 1, false, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/a"},
@@ -188,7 +189,7 @@ func TestH2_MultipleStreams(t *testing.T) {
 
 // TestH2_ChunkedDelivery — bytes split across multiple feed calls reassemble.
 func TestH2_ChunkedDelivery(t *testing.T) {
-	s := newH2State("test")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/chunked"},
@@ -258,7 +259,7 @@ func TestIsHTTP2Frame(t *testing.T) {
 // Host header is present (common for gRPC over HTTP/2), the emitted URL must
 // not be "https:///path".
 func TestH2_AuthorityFromHostHeader(t *testing.T) {
-	s := newH2State("iface-1")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 	frame := buildHeadersFrame(t, 5, true, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},
 		{Name: ":path", Value: "/phase5c2.Greeter/SayHello"},
@@ -283,7 +284,7 @@ func TestH2_AuthorityFromHostHeader(t *testing.T) {
 // a length-prefixed message inside DATA should be decoded and the message
 // body should equal the protobuf payload (framing stripped).
 func TestH2_GRPCFraming(t *testing.T) {
-	s := newH2State("iface-1")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 
 	// Build a gRPC request: HEADERS with :method=POST, :path=/svc/Method,
 	// content-type: application/grpc, followed by a DATA frame whose
@@ -325,7 +326,7 @@ func TestH2_GRPCFraming(t *testing.T) {
 // TestH2_GRPCFramingSplit: a gRPC message that arrives split across two
 // DATA frames must be reassembled (framing reassembly).
 func TestH2_GRPCFramingSplit(t *testing.T) {
-	s := newH2State("iface-1")
+	s := newH2State(akinet.TCPBidiID(uuid.New()))
 
 	headers := buildHeadersFrame(t, 3, false, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},

--- a/ebpf/loader/config.go
+++ b/ebpf/loader/config.go
@@ -11,17 +11,17 @@ type Config struct {
 	EnforcePIDAllowlist bool
 
 	// MaxCaptureBytes is the maximum number of plaintext bytes copied per
-	// event. Clamped to MAX_EVENT_PAYLOAD (1024) at the BPF level. Power
+	// event. Clamped to MAX_EVENT_PAYLOAD (4096) at the BPF level. Power
 	// of two recommended for verifier-friendly masking.
 	MaxCaptureBytes uint32
 }
 
 // Default returns the default load config: no PID allowlist enforcement,
-// 1 KiB capture per event.
+// 4 KiB capture per event.
 func Default() Config {
 	return Config{
 		EnforcePIDAllowlist: false,
-		MaxCaptureBytes:     1024,
+		MaxCaptureBytes:     4096,
 	}
 }
 
@@ -34,7 +34,7 @@ func (c Config) bpfEnforce() uint32 {
 
 func (c Config) bpfMaxCapture() uint32 {
 	if c.MaxCaptureBytes == 0 {
-		return 1024
+		return 4096
 	}
 	return c.MaxCaptureBytes
 }

--- a/ebpf/programs/event.h
+++ b/ebpf/programs/event.h
@@ -17,7 +17,7 @@
 // truncated; the full length is preserved in `len_total` for accounting.
 //
 // Mirrors OBI's FULL_BUF_SIZE (bpf/common/http_info.h). Power of two.
-#define MAX_EVENT_PAYLOAD 1024
+#define MAX_EVENT_PAYLOAD 4096
 
 // A single decrypted-bytes event emitted by an SSL_read or SSL_write
 // uretprobe. One TLS record may produce multiple events; the userspace

--- a/ebpf/programs/libssl.bpf.c
+++ b/ebpf/programs/libssl.bpf.c
@@ -215,8 +215,7 @@ static __always_inline int pid_allowed(__u32 tgid) {
 // so the BPF verifier can prove the bounded read. Modern verifiers (kernel
 // 5.2+) track conditional bounds. The old mask trick (&= MAX_EVENT_PAYLOAD-1)
 // was incorrect: when to_copy == MAX_EVENT_PAYLOAD after the runtime cap,
-// 1024 & 1023 == 0, causing every ≥ MAX_EVENT_PAYLOAD-byte payload to be
-// captured as 1 byte. Plain conditional has no such edge case.
+// 4096 & 4095 would truncate to zero at the boundary; plain conditional has no such edge case.
 static __always_inline int emit_event(
         __u64 pid_tgid,
         __u64 ssl_ctx,

--- a/ebpf/thermostat_linux.go
+++ b/ebpf/thermostat_linux.go
@@ -22,12 +22,12 @@ import (
 //
 // Algorithm (matches OBI/Pixie heuristics):
 //
-//   * Sample %CPU every 1s using /proc/self/stat (utime + stime).
-//   * If a 10s rolling window averages > HighWatermark, halve max_capture_bytes
+//   - Sample %CPU every 1s using /proc/self/stat (utime + stime).
+//   - If a 10s rolling window averages > HighWatermark, halve max_capture_bytes
 //     down to a floor of 64 bytes. Log every transition.
-//   * If a 30s rolling window averages < LowWatermark, double back up to the
+//   - If a 30s rolling window averages < LowWatermark, double back up to the
 //     configured ceiling. Log every transition.
-//   * Hard bound: never below 64, never above the user-configured ceiling.
+//   - Hard bound: never below 64, never above the user-configured ceiling.
 //
 // The thermostat keeps a snapshot of its current decision visible via
 // CurrentCap() so telemetry can include it.
@@ -51,7 +51,7 @@ type Thermostat struct {
 // watermarks.
 func NewThermostat(l *loader.Loader, ceiling uint32) *Thermostat {
 	if ceiling == 0 {
-		ceiling = 1024
+		ceiling = 4096
 	}
 	t := &Thermostat{
 		loader:        l,

--- a/test/kind/agent-daemonset-prod.yaml
+++ b/test/kind/agent-daemonset-prod.yaml
@@ -93,7 +93,6 @@ spec:
           - "kube"
           - "run"
           - "--enable-https-capture"
-          - "--enable-java-tls"
           - "--discovery-mode"
           # Namespace filtering: only monitor pods in these namespaces.
           # eBPF discovery is also scoped per-pod to its own namespace.

--- a/test/kind/agent-daemonset.yaml
+++ b/test/kind/agent-daemonset.yaml
@@ -6,7 +6,7 @@
 # data to Postman and does NOT exercise the full production code path.
 #
 # For production use (or e2e with real credentials), use agent-daemonset-prod.yaml
-# which runs `kube run --enable-https-capture --enable-java-tls --discovery-mode`.
+# which runs `kube run --enable-https-capture --discovery-mode`.
 #
 # Privileges follow docs/https-capture-design.md §8.1:
 #   - hostPID: true (so PIDs in /host/proc match the kernel's view)
@@ -73,11 +73,9 @@ spec:
       - name: agent
         image: pia-agent-ebpf:test
         imagePullPolicy: Never
-        # apidump-ebpf spike: libssl uprobes (Node, dotnet, …) + java_tls kprobe
-        # (JVM ioctl path) in one process — same log stream as production DaemonSet.
+        # apidump-ebpf spike: libssl uprobes (Node, dotnet, …) in one process.
         args:
           - "apidump-ebpf"
-          - "--enable-javatls"
           - "--stats-every=10s"
           - "--max-capture-bytes=512"
           - "--no-thermostat"

--- a/test/kind/deploy-e2e-demo.sh
+++ b/test/kind/deploy-e2e-demo.sh
@@ -59,14 +59,14 @@ fi
 
 "$CERT_DIR/gen-java-service-certs.sh"
 
-echo "==> Agent DaemonSet (production path: apidump --enable-https-capture --enable-java-tls)"
+echo "==> Agent DaemonSet (production path: kube run --enable-https-capture)"
 # Uses agent-daemonset-prod.yaml which requires POSTMAN_INSIGHTS_API_KEY.
 # For credential-free local dev, use agent-daemonset.yaml (logs to stdout only).
 kubectl apply -f "$REPO_ROOT/test/kind/agent-daemonset-prod.yaml"
 kubectl rollout restart -n postman-insights daemonset/postman-insights-agent 2>/dev/null || true
 kubectl rollout status -n postman-insights daemonset/postman-insights-agent --timeout=180s
 
-echo "==> Remove legacy javatls-capture (Java now in DaemonSet via --enable-java-tls)"
+echo "==> Remove legacy javatls-capture deployment (if present)"
 kubectl delete deployment javatls-capture -n postman-insights --ignore-not-found
 
 echo "==> test-apps namespace + TLS ConfigMap"


### PR DESCRIPTION
This pull request introduces several changes focused on improving eBPF HTTPS capture support, simplifying the build process, and removing legacy Java agent dependencies. The most significant updates include raising the default HTTPS capture size, adding a flag to disable the CPU thermostat for eBPF capture, and enhancing build and deployment flexibility by removing Java agent JARs from eBPF-only images. Additionally, new Makefile and Dockerfile targets streamline building eBPF-enabled binaries, and related tests and configuration options have been updated accordingly.

**eBPF HTTPS Capture Improvements:**

* Increased the default `BodySizeCap` for HTTPS eBPF capture from 1024 to 4096 bytes across the codebase, improving per-event payload coverage.
* Added a `DisableThermostat` option (and `--no-thermostat` CLI flag) to allow disabling the CPU load-based dynamic reduction of capture size, useful for debugging and demos.

**Build and Deployment Simplification:**

* Removed all Java agent JARs and test workloads from the eBPF-only deployment image (`build-scripts/Dockerfile.ebpf`), making it lighter and focused solely on the Go agent binary.
* Added a new `build-scripts/Dockerfile.ebpf-bin` and corresponding `make docker-build-ebpf` target for building and exporting a static, eBPF-enabled CLI binary without deployment dependencies.

**Configuration and Testing Enhancements:**

* Added support for configuring a cBPF port exclusion (`CBPFExcludePort`) for HTTPS capture, with propagation through Daemonset arguments and tests to verify correct behavior.

**Development Environment Updates:**

* Added VSCode `gopls` settings to enable type checking of eBPF loader sources on macOS by cross-compiling as Linux with the required build tags.

**Cleanup:**

* Removed Java agent and Gradle installation from the development Dockerfile, as well as the `helm-smoke` CI job, reflecting the migration away from Java-based instrumentation and unused CI checks.