### PR TITLE
fix(ebpf): route captured events by netns inode, not PID

### DIFF
--- a/apidump/ebpf_integration.go
+++ b/apidump/ebpf_integration.go
@@ -286,6 +286,7 @@ func startHTTPSeBPFCapture(
 			ebpfArgs.FactorySelector,
 			out,
 			ebpfArgs.ProcRoot,
+			args.HTTPS.ContainerNetnsInode,
 		)
 		// Expose node-level handles to the telemetry worker (mirrors HookLoader).
 		if ebpfArgs.HookLoader != nil {

--- a/apidump/ebpf_integration.go
+++ b/apidump/ebpf_integration.go
@@ -280,7 +280,7 @@ func startHTTPSeBPFCapture(
 	//  - NodeCollector nil (standalone apidump / tests): original ebpf.Collect()
 	//    path, behaviour completely unchanged.
 	if args.HTTPS.NodeCollector != nil {
-		unsubscribe := args.HTTPS.NodeCollector.Subscribe(
+		unsubscribe, adapter := args.HTTPS.NodeCollector.Subscribe(
 			captureCtx,
 			ebpfArgs.Discovery,
 			ebpfArgs.FactorySelector,
@@ -288,13 +288,16 @@ func startHTTPSeBPFCapture(
 			ebpfArgs.ProcRoot,
 			args.HTTPS.ContainerNetnsInode,
 		)
-		// Expose node-level handles to the telemetry worker (mirrors HookLoader).
+		// Expose node-level handles + this pod's adapter to the telemetry worker
+		// (mirrors HookLoader). The adapter carries the per-pod MessagesEmitted /
+		// FlowsActive counters, so passing it makes ebpf-stats msgs/flows_active
+		// reflect the NodeCollector path instead of always reading 0.
 		if ebpfArgs.HookLoader != nil {
 			ebpfArgs.HookLoader(
 				args.HTTPS.NodeCollector.Loader(),
 				args.HTTPS.NodeCollector.Thermostat(),
 				args.HTTPS.NodeCollector.Manager(),
-				nil, // per-pod adapter is internal to NodeCollector.Subscribe
+				adapter,
 			)
 		}
 		wg.Add(1)

--- a/ebpf/events/decode.go
+++ b/ebpf/events/decode.go
@@ -40,6 +40,7 @@ func Decode(raw []byte) (*SSLEvent, error) {
 	e.FD = int32(binary.LittleEndian.Uint32(raw[off:]));    off += 4
 	e.Direction = raw[off];                                  off += 1
 	off += 3 // _pad
+	e.NetNS = binary.LittleEndian.Uint32(raw[off:]);        off += 4
 
 	n := int(e.LenCaptured)
 	if n > MaxEventPayload {

--- a/ebpf/events/event.go
+++ b/ebpf/events/event.go
@@ -28,6 +28,7 @@ type SSLEvent struct {
 	FD          int32  // socket fd associated with the SSL*, or -1 if unknown
 	Direction   uint8  // DirEgress or DirIngress
 	_           [3]byte
+	NetNS       uint32 // network-namespace inode (routing key; matches /proc/<pid>/ns/net)
 	Payload     [MaxEventPayload]byte
 }
 

--- a/ebpf/node_collector_linux.go
+++ b/ebpf/node_collector_linux.go
@@ -11,13 +11,20 @@ package ebpf
 //
 // Design:
 //   - ONE loader.Load() → one BPF program set, one ring buffer, one uprobe manager.
-//   - ONE ring buffer reader goroutine dispatches events to subscribers by PID.
+//   - ONE ring buffer reader goroutine dispatches events to subscribers,
+//     primarily by network-namespace inode (see routeSub) with a PID fallback.
 //   - ONE thermostat and rate-cap refiller run at the node level.
 //   - Per-pod: own discovery channel, own events.Adapter, own out channel.
 //     Subscribe() registers the pod; the returned cancel unregisters it.
 //
-// Thread safety: pidToSub is protected by mu. Subscribe/unsubscribe and the
-// event-dispatch loop all acquire the appropriate lock.
+// Routing key: events are routed by the pod's network-namespace inode, which is
+// stable across PID namespaces. The BPF-stamped `pid` is the init-namespace
+// TGID and does NOT match discovery's node-namespace PID in nested setups
+// (KIND / k3d / minikube --driver=docker), so PID is only a fallback for
+// non-nested nodes.
+//
+// Thread safety: netnsToSub and pidToSub are protected by mu. Subscribe/
+// unsubscribe and the event-dispatch loop all acquire the appropriate lock.
 
 import (
 	"context"
@@ -33,11 +40,8 @@ import (
 	"github.com/postmanlabs/postman-insights-agent/printer"
 )
 
-// podSub holds per-pod state registered via Subscribe.
-type podSub struct {
-	adapter *events.Adapter
-	out     chan<- akinet.ParsedNetworkTraffic
-}
+// podSub and routeSub live in sub.go (build-tag-free) so the routing logic is
+// unit-tested on every platform.
 
 // NodeCollector is a node-scoped eBPF coordinator. Create one per agent pod
 // via NewNodeCollector, start it with Run, then call Subscribe for each
@@ -56,7 +60,11 @@ type NodeCollector struct {
 	// maxCaptureBytes is the initial BPF capture cap (may be lowered by thermostat).
 	maxCaptureBytes uint32
 
-	mu       sync.RWMutex
+	mu sync.RWMutex
+	// netnsToSub is the primary routing table: pod netns inode -> subscriber.
+	netnsToSub map[uint64]*podSub
+	// pidToSub is a fallback routing table (node-ns PID -> subscriber) used on
+	// non-nested nodes where BPF PIDs match discovery PIDs.
 	pidToSub map[uint32]*podSub
 }
 
@@ -100,6 +108,7 @@ func NewNodeCollector(cfg NodeCollectorConfig) (*NodeCollector, error) {
 		flowIdleTimeout: cfg.FlowIdleTimeout,
 		rateCapPerSec:   cfg.RateCapPerSec,
 		maxCaptureBytes: cfg.MaxCaptureBytes,
+		netnsToSub:      make(map[uint64]*podSub),
 		pidToSub:        make(map[uint32]*podSub),
 	}
 	return nc, nil
@@ -162,7 +171,7 @@ func (nc *NodeCollector) Run(ctx context.Context) error {
 				return nil
 			}
 			nc.mu.RLock()
-			sub := nc.pidToSub[ev.PID]
+			sub := routeSub(nc.netnsToSub, nc.pidToSub, uint64(ev.NetNS), ev.PID)
 			nc.mu.RUnlock()
 			if sub != nil {
 				sub.adapter.Feed(ev, nc.monoEpoch)
@@ -170,8 +179,14 @@ func (nc *NodeCollector) Run(ctx context.Context) error {
 
 		case <-gcTicker.C:
 			nc.mu.RLock()
-			adapters := make([]*events.Adapter, 0, len(nc.pidToSub))
+			adapters := make([]*events.Adapter, 0, len(nc.netnsToSub)+len(nc.pidToSub))
 			seen := make(map[*events.Adapter]struct{})
+			for _, s := range nc.netnsToSub {
+				if _, ok := seen[s.adapter]; !ok {
+					adapters = append(adapters, s.adapter)
+					seen[s.adapter] = struct{}{}
+				}
+			}
 			for _, s := range nc.pidToSub {
 				if _, ok := seen[s.adapter]; !ok {
 					adapters = append(adapters, s.adapter)
@@ -190,20 +205,23 @@ func (nc *NodeCollector) Run(ctx context.Context) error {
 
 // Subscribe registers a pod subscriber with the NodeCollector. It starts a
 // goroutine that drives discovery (attaching/detaching uprobes) and routes
-// BPF events for the pod's PIDs to out via an events.Adapter.
+// BPF events for the pod to out via an events.Adapter.
 //
 // disco is a /proc-scoped discovery channel filtered to the pod's netns inode
-// (or namespace). factorySelector and procRoot mirror the apidump pipeline.
-// out is owned by the caller; it is never closed by Subscribe.
+// (or namespace). netnsInode is the pod's network-namespace inode and is the
+// primary routing key (0 disables netns routing, falling back to PID).
+// factorySelector and procRoot mirror the apidump pipeline. out is owned by
+// the caller; it is never closed by Subscribe.
 //
 // Returns a cancel func. Call it (and drain out) when the pod terminates to
-// unregister PIDs and stop the subscription goroutine.
+// unregister the pod and stop the subscription goroutine.
 func (nc *NodeCollector) Subscribe(
 	ctx context.Context,
 	disco <-chan discovery.Target,
 	factorySelector akinet.TCPParserFactorySelector,
 	out chan<- akinet.ParsedNetworkTraffic,
 	procRoot string,
+	netnsInode uint64,
 ) context.CancelFunc {
 	subCtx, cancel := context.WithCancel(ctx)
 
@@ -214,15 +232,18 @@ func (nc *NodeCollector) Subscribe(
 		go preResolveLoop(subCtx, nc.ldr, adapter.Resolver, adapter, 5*time.Millisecond)
 	}
 
-	go func() {
-		defer func() {
-			// On exit: unregister all PIDs this subscription may still own.
-			// (Normal path: Removed events already unregistered them one by one.)
-			if adapter.Resolver != nil {
-				// Nothing to clean up in resolver per-sub — it's stateless per PID.
-			}
-		}()
+	// One subscriber per pod. Register it by netns inode immediately (the netns
+	// is known upfront, unlike PIDs which arrive via discovery). This is the key
+	// that events actually route on; PID registration below is only a fallback
+	// for non-nested nodes.
+	sub := &podSub{adapter: adapter, out: out}
+	if netnsInode != 0 {
+		nc.mu.Lock()
+		nc.netnsToSub[netnsInode] = sub
+		nc.mu.Unlock()
+	}
 
+	go func() {
 		// Track which PIDs this subscription registered so we can clean up on
 		// cancel even if discovery doesn't emit Removed events in time.
 		ownedPIDs := make(map[uint32]struct{})
@@ -230,8 +251,11 @@ func (nc *NodeCollector) Subscribe(
 		for {
 			select {
 			case <-subCtx.Done():
-				// Unregister any remaining PIDs.
+				// Unregister the pod's netns route and any remaining PIDs.
 				nc.mu.Lock()
+				if netnsInode != 0 {
+					delete(nc.netnsToSub, netnsInode)
+				}
 				for pid := range ownedPIDs {
 					delete(nc.pidToSub, uint32(pid))
 				}
@@ -271,7 +295,6 @@ func (nc *NodeCollector) Subscribe(
 						tgt.PID, tgt.Lib.HostPath, err)
 					continue
 				}
-				sub := &podSub{adapter: adapter, out: out}
 				nc.mu.Lock()
 				nc.pidToSub[uint32(tgt.PID)] = sub
 				nc.mu.Unlock()

--- a/ebpf/node_collector_linux.go
+++ b/ebpf/node_collector_linux.go
@@ -213,8 +213,10 @@ func (nc *NodeCollector) Run(ctx context.Context) error {
 // factorySelector and procRoot mirror the apidump pipeline. out is owned by
 // the caller; it is never closed by Subscribe.
 //
-// Returns a cancel func. Call it (and drain out) when the pod terminates to
-// unregister the pod and stop the subscription goroutine.
+// Returns a cancel func and the pod's events.Adapter. Call cancel (and drain
+// out) when the pod terminates to unregister the pod and stop the subscription
+// goroutine. The returned adapter is exposed so the caller can feed its
+// per-pod capture counters (MessagesEmitted, FlowsActive) into telemetry.
 func (nc *NodeCollector) Subscribe(
 	ctx context.Context,
 	disco <-chan discovery.Target,
@@ -222,7 +224,7 @@ func (nc *NodeCollector) Subscribe(
 	out chan<- akinet.ParsedNetworkTraffic,
 	procRoot string,
 	netnsInode uint64,
-) context.CancelFunc {
+) (context.CancelFunc, *events.Adapter) {
 	subCtx, cancel := context.WithCancel(ctx)
 
 	adapter := events.NewAdapter(factorySelector, out)
@@ -307,5 +309,5 @@ func (nc *NodeCollector) Subscribe(
 		}
 	}()
 
-	return cancel
+	return cancel, adapter
 }

--- a/ebpf/node_collector_stub.go
+++ b/ebpf/node_collector_stub.go
@@ -14,6 +14,7 @@ import (
 	"github.com/akitasoftware/akita-libs/akinet"
 
 	"github.com/postmanlabs/postman-insights-agent/ebpf/discovery"
+	"github.com/postmanlabs/postman-insights-agent/ebpf/events"
 	"github.com/postmanlabs/postman-insights-agent/ebpf/loader"
 	"github.com/postmanlabs/postman-insights-agent/ebpf/uprobes"
 )
@@ -46,6 +47,6 @@ func (nc *NodeCollector) Subscribe(
 	_ chan<- akinet.ParsedNetworkTraffic,
 	_ string,
 	_ uint64,
-) context.CancelFunc {
-	return func() {}
+) (context.CancelFunc, *events.Adapter) {
+	return func() {}, nil
 }

--- a/ebpf/node_collector_stub.go
+++ b/ebpf/node_collector_stub.go
@@ -45,6 +45,7 @@ func (nc *NodeCollector) Subscribe(
 	_ akinet.TCPParserFactorySelector,
 	_ chan<- akinet.ParsedNetworkTraffic,
 	_ string,
+	_ uint64,
 ) context.CancelFunc {
 	return func() {}
 }

--- a/ebpf/node_collector_test.go
+++ b/ebpf/node_collector_test.go
@@ -101,7 +101,7 @@ func TestNodeCollectorStub_Subscribe(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
-	cancel := nc.Subscribe(ctx, disco, nil, out, "", 0)
+	cancel, _ := nc.Subscribe(ctx, disco, nil, out, "", 0)
 	require.NotNil(t, cancel, "Subscribe must return a non-nil cancel func")
 
 	// Calling cancel must not panic.

--- a/ebpf/node_collector_test.go
+++ b/ebpf/node_collector_test.go
@@ -101,7 +101,7 @@ func TestNodeCollectorStub_Subscribe(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
-	cancel := nc.Subscribe(ctx, disco, nil, out, "")
+	cancel := nc.Subscribe(ctx, disco, nil, out, "", 0)
 	require.NotNil(t, cancel, "Subscribe must return a non-nil cancel func")
 
 	// Calling cancel must not panic.

--- a/ebpf/programs/event.h
+++ b/ebpf/programs/event.h
@@ -36,6 +36,10 @@ struct ssl_event {
     __s32 fd;                             // socket fd associated with ssl_ctx, or -1
     __u8  direction;                      // DIR_EGRESS or DIR_INGRESS
     __u8  _pad[3];                        // align to 8 bytes
+    __u32 netns;                          // network-namespace inode (task->nsproxy->net_ns->ns.inum).
+                                          // Routing key: stable across PID namespaces, unlike `pid`,
+                                          // so it matches the pod netns discovery filters on even in
+                                          // nested environments (KIND/k3d/minikube-docker).
     __u8  payload[MAX_EVENT_PAYLOAD];
 };
 

--- a/ebpf/programs/libssl.bpf.c
+++ b/ebpf/programs/libssl.bpf.c
@@ -259,6 +259,15 @@ static __always_inline int emit_event(
     e->direction    = direction;
     __builtin_memset(e->_pad, 0, sizeof(e->_pad));
 
+    // Network-namespace inode of the calling task. This is the routing key the
+    // userspace NodeCollector matches against the pod's netns (from
+    // /proc/<pid>/ns/net). Unlike `pid` (bpf_get_current_pid_tgid returns the
+    // init-namespace tgid), the netns inode is identical across PID-namespace
+    // nesting, so routing works even when the agent runs inside a nested node
+    // container (KIND/k3d/minikube --driver=docker). 0 if it cannot be read.
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    e->netns = BPF_CORE_READ(task, nsproxy, net_ns, ns.inum);
+
     if (bpf_probe_read_user(e->payload, to_copy, user_buf) != 0) {
         bpf_ringbuf_discard(e, 0);
         counter_inc(2, 1);  // probe_read_user failed (target VMA gone, etc.)

--- a/ebpf/sub.go
+++ b/ebpf/sub.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpf
+
+// This file is intentionally build-tag-free so the routing logic (routeSub) is
+// compiled and unit-tested on every platform, independent of the BPF loader.
+
+import (
+	"github.com/akitasoftware/akita-libs/akinet"
+
+	"github.com/postmanlabs/postman-insights-agent/ebpf/events"
+)
+
+// podSub holds per-pod state registered via NodeCollector.Subscribe.
+type podSub struct {
+	adapter *events.Adapter
+	out     chan<- akinet.ParsedNetworkTraffic
+}
+
+// routeSub selects the subscriber for a BPF event.
+//
+// It routes primarily by the event's network-namespace inode (netnsInode),
+// which is stable across PID namespaces. This is what makes capture work in
+// nested environments (KIND / k3d / minikube --driver=docker): there the BPF
+// program stamps events with the init-namespace TGID, which never matches the
+// node-namespace PID that discovery registered, but both the event's netns and
+// the pod's netns resolve to the same inode.
+//
+// It falls back to the PID map when the netns inode is unavailable (0) or has
+// no registered subscriber — preserving the original behaviour on non-nested
+// nodes where /host/proc is the init namespace and PIDs already match.
+//
+// Returns nil when no subscriber matches (the event is dropped).
+func routeSub(byNetns map[uint64]*podSub, byPID map[uint32]*podSub, netnsInode uint64, pid uint32) *podSub {
+	if netnsInode != 0 {
+		if s := byNetns[netnsInode]; s != nil {
+			return s
+		}
+	}
+	return byPID[pid]
+}

--- a/ebpf/sub_test.go
+++ b/ebpf/sub_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpf
+
+import "testing"
+
+// These tests exercise the pure routing decision (routeSub) with no BPF loader
+// or kernel dependency, so they run on every platform via plain `go test`.
+
+func TestRouteSub_NetnsMatchWins(t *testing.T) {
+	byNetnsSub := &podSub{}
+	byPIDSub := &podSub{}
+	byNetns := map[uint64]*podSub{4026533959: byNetnsSub}
+	byPID := map[uint32]*podSub{3146: byPIDSub}
+
+	// netns matches -> route by netns, even though the (init-ns) pid would also
+	// resolve via the fallback map. This is the KIND case: eventPID=4399 has no
+	// entry, but the netns does.
+	if got := routeSub(byNetns, byPID, 4026533959, 4399); got != byNetnsSub {
+		t.Fatalf("expected netns subscriber %p, got %p", byNetnsSub, got)
+	}
+}
+
+func TestRouteSub_PIDFallbackWhenNetnsZero(t *testing.T) {
+	byPIDSub := &podSub{}
+	byNetns := map[uint64]*podSub{4026533959: {}}
+	byPID := map[uint32]*podSub{3146: byPIDSub}
+
+	// netns inode unavailable (0) -> fall back to PID (non-nested node behaviour).
+	if got := routeSub(byNetns, byPID, 0, 3146); got != byPIDSub {
+		t.Fatalf("expected PID fallback subscriber %p, got %p", byPIDSub, got)
+	}
+}
+
+func TestRouteSub_PIDFallbackWhenNetnsUnregistered(t *testing.T) {
+	byPIDSub := &podSub{}
+	byNetns := map[uint64]*podSub{4026533959: {}}
+	byPID := map[uint32]*podSub{3146: byPIDSub}
+
+	// A non-zero but unregistered netns falls back to PID rather than dropping.
+	if got := routeSub(byNetns, byPID, 9999, 3146); got != byPIDSub {
+		t.Fatalf("expected PID fallback subscriber %p, got %p", byPIDSub, got)
+	}
+}
+
+func TestRouteSub_NoMatchReturnsNil(t *testing.T) {
+	byNetns := map[uint64]*podSub{4026533959: {}}
+	byPID := map[uint32]*podSub{3146: {}}
+
+	// Neither netns nor pid registered -> nil (event is dropped).
+	if got := routeSub(byNetns, byPID, 9999, 4399); got != nil {
+		t.Fatalf("expected nil (drop), got %p", got)
+	}
+}


### PR DESCRIPTION
The node-scoped BPF loader stamps each event with the init-namespace TGID (bpf_get_current_pid_tgid), while discovery/registration key on the node-namespace PID read from /host/proc. In nested-PID-namespace environments (KIND, k3d, minikube --driver=docker) these never match, so every event was dropped in the dispatch loop and no HTTPS traffic was captured.

Emit the network-namespace inode (task->nsproxy->net_ns->ns.inum) on each event and route by it. The netns inode is stable across PID namespaces and matches the pod netns discovery already filters on. PID routing is kept as a fallback for non-nested nodes.

- event.h / libssl.bpf.c: add ssl_event.netns, populated via CO-RE
- events: decode NetNS; SSLEvent gains a NetNS field
- NodeCollector: add netnsToSub map, route via routeSub (netns-first with PID fallback); Subscribe takes the pod netns inode
- sub.go: build-tag-free podSub + routeSub, covered by unit tests

Requires `make generate-ebpf` (ssl_event size changed).