### PR TITLE
Handle negative latency and truncated packet messages

### DIFF
--- a/ebpf/events/adapter.go
+++ b/ebpf/events/adapter.go
@@ -234,12 +234,20 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 	chunk := append([]byte(nil), ev.Bytes()...)
 	st.pending.Append(memview.New(chunk))
 
-	a.drain(key, st, ev.Time(monoEpoch))
+	a.drain(key, st, ev.Time(monoEpoch), ev.Truncated())
 }
 
 // drain runs the parser state machine until no progress can be made.
 // Caller holds a.mu.
-func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
+//
+// truncated indicates the SSL call that produced the bytes just appended was
+// truncated at the per-event capture cap (len_total > len_captured). The
+// missing tail was dropped in-kernel and will NEVER arrive, so we must not let
+// the incomplete message keep the parser open — otherwise it head-of-line
+// blocks every later message on the same connection (the request/response
+// drift bug). We finalize such a message best-effort (isEnd=true) and, if that
+// fails, abandon just this message's parser while keeping the flow alive.
+func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time, truncated bool) {
 	for st.pending.Len() > 0 && !st.dropped {
 		if st.parser == nil {
 			factory, decision, discardFront := a.FactorySelector.Select(st.pending, false)
@@ -251,6 +259,13 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 				a.dropFlow(key, st)
 				return
 			case akinet.NeedMoreData:
+				// Can't identify the protocol yet. If the bytes were truncated,
+				// the identifying tail is gone — abandon this message but keep the
+				// flow alive so the next SSL call parses cleanly.
+				if truncated {
+					a.resetParser(st)
+					return
+				}
 				if st.pending.Len() > MaxPendingPerFlow {
 					a.dropFlow(key, st)
 				}
@@ -263,24 +278,40 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 			}
 		}
 
-		result, unused, _, err := st.parser.Parse(st.pending, false)
+		// isEnd=truncated forces the parser to finalize best-effort when the
+		// tail is unrecoverable (per the TCPParser contract it then returns a
+		// non-nil result or an error), instead of parking in NeedMoreData and
+		// head-of-line blocking every later message on the same connection.
+		result, unused, _, err := st.parser.Parse(st.pending, truncated)
 		if err != nil {
-			// Parse error — flow is permanently un-parseable.
+			if truncated {
+				// Truncated + unparseable: drop only this message's parser, keep
+				// the flow so subsequent messages still pair correctly.
+				a.resetParser(st)
+				return
+			}
+			// Genuine parse error on a complete stream — flow is un-parseable.
 			a.dropFlow(key, st)
 			return
 		}
 		if result == nil {
-			// Parser absorbed all bytes and awaits more. Clear pending; next
-			// event will append fresh bytes.
+			// Only reachable when isEnd=false: parser absorbed all bytes and
+			// awaits more. Clear pending; the next event appends fresh bytes.
 			st.pending.Clear()
 			return
 		}
 
-		// Got a complete message. Emit it and continue with unused tail.
+		// Got a complete (or best-effort finalized) message. Emit and continue.
 		a.Out <- a.toPNT(st, key, result, now)
 		a.MessagesEmitted++
 		st.parser = nil
 		st.pending = unused
+		if truncated {
+			// The remainder after a truncated SSL call is not a clean message
+			// boundary — don't try to reparse it as a new message.
+			st.pending.Clear()
+			return
+		}
 		// Any leftover (pipelined) bytes belong to the next message, and they
 		// arrived at "now" — start its clock here so it doesn't inherit this
 		// message's start time.
@@ -288,6 +319,14 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 			st.msgStart = now
 		}
 	}
+}
+
+// resetParser abandons the current message's parser without marking the flow
+// dropped, so subsequent messages on the same connection keep parsing and
+// pairing. Contrast with dropFlow, which kills the flow permanently.
+func (a *Adapter) resetParser(st *flowState) {
+	st.parser = nil
+	st.pending.Clear()
 }
 
 func (a *Adapter) emitH2PNT(key FlowKey, st *flowState, pnt akinet.ParsedNetworkTraffic) {

--- a/ebpf/events/adapter.go
+++ b/ebpf/events/adapter.go
@@ -123,10 +123,16 @@ func isHTTPRequestParserFactory(factory akinet.TCPParserFactory) bool {
 }
 
 type flowState struct {
-	parser    akinet.TCPParser
-	pending   memview.MemView
-	conn      *tlsConnState
+	parser akinet.TCPParser
+	pending memview.MemView
+	conn    *tlsConnState
+	// firstSeen is when this flow was first observed (connection-level; used as
+	// a fallback and for GC). msgStart is when the CURRENT message's first byte
+	// arrived — this is what a witness's ObservationTime must use, otherwise
+	// every message on a keep-alive flow inherits the flow's first-ever
+	// timestamp (causing negative processing latency and wrong witness times).
 	firstSeen time.Time
+	msgStart  time.Time
 	lastSeen  time.Time
 	totalIn   int  // total bytes ever observed on this flow
 	dropped   bool // permanent: malformed or oversized
@@ -218,6 +224,12 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 		return
 	}
 
+	// Mark the start of a new message: when there are no buffered bytes for an
+	// in-progress message, this event carries the first byte of the next one.
+	if st.pending.Len() == 0 {
+		st.msgStart = ev.Time(monoEpoch)
+	}
+
 	// Copy bytes — the underlying ringbuf record is reused once Feed returns.
 	chunk := append([]byte(nil), ev.Bytes()...)
 	st.pending.Append(memview.New(chunk))
@@ -269,6 +281,12 @@ func (a *Adapter) drain(key FlowKey, st *flowState, now time.Time) {
 		a.MessagesEmitted++
 		st.parser = nil
 		st.pending = unused
+		// Any leftover (pipelined) bytes belong to the next message, and they
+		// arrived at "now" — start its clock here so it doesn't inherit this
+		// message's start time.
+		if st.pending.Len() > 0 {
+			st.msgStart = now
+		}
 	}
 }
 
@@ -310,10 +328,19 @@ func (a *Adapter) dropFlow(key FlowKey, st *flowState) {
 // SrcIP=local, DstIP=remote when we wrote (egress) — what we sent goes from
 // us to them. For ingress (we received bytes), SrcIP=remote, DstIP=local.
 func (a *Adapter) toPNT(st *flowState, key FlowKey, c akinet.ParsedNetworkContent, now time.Time) akinet.ParsedNetworkTraffic {
+	// ObservationTime is the start of THIS message (msgStart), not the flow's
+	// first-ever message (firstSeen) — otherwise every message on a keep-alive
+	// connection inherits the flow's creation time, producing negative
+	// processing latency and incorrect witness timestamps. Fall back to
+	// firstSeen if msgStart was never set.
+	obsTime := st.msgStart
+	if obsTime.IsZero() {
+		obsTime = st.firstSeen
+	}
 	pnt := akinet.ParsedNetworkTraffic{
 		Content:         c,
 		Interface:       st.ifaceTag,
-		ObservationTime: st.firstSeen,
+		ObservationTime: obsTime,
 		FinalPacketTime: now,
 	}
 	if st.conn.socketResolved {


### PR DESCRIPTION
This pull request makes several improvements to how SSL/TLS message parsing handles truncated packet captures and message timing. The changes ensure more accurate message timestamps, prevent parser stalls on incomplete messages, and improve message pairing on persistent connections.

**Handling of message timing and observation:**

* Added a new `msgStart` field to `flowState` to track when the current message's first byte arrives, ensuring each message gets an accurate `ObservationTime` instead of inheriting the flow's start time. (`ebpf/events/adapter.go`)
**Robustness to truncated SSL events:**

* Enhanced the `drain` logic to detect and handle truncated SSL events, finalizing or abandoning only the affected message parser instead of blocking the entire flow. (`ebpf/events/adapter.go`)
* Introduced a new `resetParser` helper to abandon the current message parser without dropping the whole flow, allowing subsequent messages to be parsed and paired correctly. (`ebpf/events/adapter.go`)

**General parser and flow handling improvements:**

* Updated parser calls to use the `truncated` flag, ensuring best-effort finalization when data loss is detected, and clarified comments to document the new behaviors. (`ebpf/events/adapter.go`)

These changes together make message parsing more resilient to packet loss and improve the accuracy of message timing for downstream consumers.