### PR TITLE
[eBPF] Fix HTTP/2 witness-ID collisions and mid-connection HPACK desync

### DIFF
--- a/ebpf/events/adapter.go
+++ b/ebpf/events/adapter.go
@@ -93,6 +93,27 @@ type tlsConnState struct {
 	unmatchedRequests []int
 	activeFlowCount   int
 
+	// gotls reuses the same SSL* pointer (and therefore the same connKey and
+	// this tlsConnState, including bidiID) across successive H2 connections,
+	// and H2 stream IDs restart at 1 on each connection. Because an H2 witness
+	// ID is (StreamID=bidiID, Seq=streamID), a reused bidiID makes every new
+	// connection collide on stream 1, 3, 5... To avoid that, h2State.feed()
+	// detects the client preface that begins each connection and, if this conn
+	// has already carried H2 traffic (h2Seen), bumps h2Epoch and regenerates
+	// bidiID so the new connection gets a fresh witness namespace.
+	//
+	// h2Seen:  false until the first H2 client preface on this conn (so the
+	//          first connection keeps the id the conn was created with).
+	// h2Epoch: increments once per subsequent connection. Each direction's
+	//          h2State caches the epoch it reset at and, when it observes the
+	//          shared epoch advance, resets its own per-connection HPACK/stream
+	//          state. This keeps both directions on the same bidiID (so
+	//          request/response still pair) and gives each connection a fresh
+	//          HPACK context (the peer's dynamic table also resets per
+	//          connection).
+	h2Seen  bool
+	h2Epoch uint64
+
 	// Resolved 4-tuple shared by ingress and egress on this TLS connection.
 	socketResolved bool
 	localIP        net.IP
@@ -204,6 +225,10 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 	st.totalIn += int(ev.LenCaptured)
 
 	// If we've already committed this flow to the HTTP/2 path, stay there.
+	// Note: the HTTP/1 truncation recovery in drain() has no HTTP/2 equivalent —
+	// a truncated event (ev.Truncated()) leaves a hole in the frame stream, so
+	// feed() may wait indefinitely for 9+length bytes or misalign on the next
+	// frame and corrupt the rest of the connection's decode.
 	if st.h2 != nil {
 		for _, pnt := range st.h2.feed(ev.Bytes(), ev.Time(monoEpoch), st.ifaceTag) {
 			a.emitH2PNT(key, st, pnt)
@@ -217,7 +242,12 @@ func (a *Adapter) Feed(ev *SSLEvent, monoEpoch time.Time) {
 	// the common case for gotls because the TLS handshake + preface complete
 	// before the uprobes catch their first non-handshake call).
 	if st.pending.Len() == 0 && (IsHTTP2Preface(ev.Bytes()) || IsHTTP2Frame(ev.Bytes())) {
-		st.h2 = newH2State(st.conn.bidiID)
+		// New-connection detection and the per-connection witness-namespace
+		// (bidiID) regeneration are handled inside h2State.feed() at the client-
+		// preface boundary, because a reused SSL* keeps the same flowState/h2State
+		// (this branch is only hit the first time, or after a GC reset) — see the
+		// preface handling in feed().
+		st.h2 = newH2State(st.conn)
 		for _, pnt := range st.h2.feed(ev.Bytes(), ev.Time(monoEpoch), st.ifaceTag) {
 			a.emitH2PNT(key, st, pnt)
 		}

--- a/ebpf/events/http2.go
+++ b/ebpf/events/http2.go
@@ -36,7 +36,6 @@ package events
 
 import (
 	"encoding/binary"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -98,13 +97,37 @@ type h2State struct {
 	// Per-stream state, keyed by stream ID.
 	streams map[uint32]*h2Stream
 
-	// Connection-flow identity used for emitted PNTs.
-	bidiID akinet.TCPBidiID
+	// conn is the shared per-TLS-connection state. The witness namespace
+	// (bidiID) lives here rather than being snapshotted, so that when the
+	// adapter regenerates conn.bidiID for a reused SSL* pointer, BOTH direction
+	// decoders emit under the new id and request/response still pair. Read the
+	// id via s.bidiID().
+	conn *tlsConnState
+
+	// epoch is the conn.h2Epoch value this decoder last reset at. When the
+	// shared epoch advances (a new connection began on the reused SSL*, detected
+	// via the client preface on either direction), feed() resets this decoder's
+	// per-connection state so we don't carry stream/HPACK state across
+	// connections. See tlsConnState.h2Epoch.
+	epoch uint64
 
 	// hpackErrors counts HEADERS+CONTINUATION decode failures. Non-zero on
 	// a flow strongly suggests we attached mid-connection and missed the
 	// dynamic-table state. Exposed via HPACKErrors() for telemetry.
 	hpackErrors uint64
+
+	// hpackDesynced latches true after the first HPACK decode failure. A
+	// decode failure proves the encoder's dynamic table diverged from ours
+	// (we attached mid-connection and missed the inserts that populated it).
+	// This is UNRECOVERABLE: we can never reconstruct entries we never saw.
+	// Critically, a desynced table can still decode later blocks *without
+	// error* yet return the WRONG header values (a stale/mis-indexed dynamic
+	// entry), which would emit corrupt method/path/status into the UI. So once
+	// desynced we stop decoding HEADERS on this connection entirely and emit
+	// nothing further from it — dropping the connection is strictly safer than
+	// risking silently-wrong data. New connections (caught at their preface)
+	// are unaffected and decode normally.
+	hpackDesynced bool
 }
 
 // HPACKErrors returns the number of HEADERS decode failures on this flow.
@@ -148,17 +171,47 @@ type h2Stream struct {
 // adapter's MaxPendingPerFlow.
 const h2MaxBodyBytes = 1 * 1024 * 1024
 
-func newH2State(bidiID akinet.TCPBidiID) *h2State {
+func newH2State(conn *tlsConnState) *h2State {
 	return &h2State{
 		hpack:   hpack.NewDecoder(4096, nil),
 		streams: map[uint32]*h2Stream{},
-		bidiID:  bidiID,
+		conn:    conn,
 	}
+}
+
+// bidiID returns the live per-connection witness namespace. It is read fresh
+// (not snapshotted) so a mid-life regeneration by the adapter is reflected in
+// every subsequently emitted stream on this connection.
+func (s *h2State) bidiID() akinet.TCPBidiID {
+	return s.conn.bidiID
+}
+
+// resetForNewConnection clears the per-connection decode state when the reused
+// SSL* pointer rolls to a new connection. HPACK state and stream state are
+// strictly per-connection (RFC 7540/7541), so carrying them across connections
+// would desync the dynamic table and collide stream IDs. It intentionally does
+// NOT touch s.pending (the caller is mid-parse) or the shared conn/epoch.
+func (s *h2State) resetForNewConnection() {
+	s.hpack = hpack.NewDecoder(4096, nil)
+	s.streams = map[uint32]*h2Stream{}
+	s.headerBlock = s.headerBlock[:0]
+	s.headersStreamID = 0
+	s.headersEndStream = false
+	s.hpackDesynced = false
 }
 
 // IsHTTP2Preface returns true if the given bytes start with the HTTP/2
 // connection preface or look like a SETTINGS frame at stream_id=0 (which is
 // what the server sends back as its half of the preface).
+// isH2ClientPreface reports whether b begins with the HTTP/2 client connection
+// preface ("PRI * HTTP/2.0..."). Unlike IsHTTP2Preface it does NOT match the
+// server-side SETTINGS frame, so it fires exactly once per connection (on the
+// client-write side). The adapter uses it to regenerate the per-connection
+// bidiID exactly once when an SSL* pointer is reused for a new connection.
+func isH2ClientPreface(b []byte) bool {
+	return len(b) >= len(H2Preface) && string(b[:len(H2Preface)]) == H2Preface
+}
+
 func IsHTTP2Preface(b []byte) bool {
 	if len(b) >= len(H2Preface) && string(b[:len(H2Preface)]) == H2Preface {
 		return true
@@ -258,9 +311,33 @@ func (s *h2State) feed(data []byte, now time.Time, ifaceTag string) []akinet.Par
 
 	s.pending = append(s.pending, data...)
 
-	// If we haven't yet consumed the preface and it's present, skip it.
-	if len(s.pending) >= len(H2Preface) && string(s.pending[:len(H2Preface)]) == H2Preface {
+	// A client preface at the start of pending marks the beginning of a
+	// connection. Because a reused SSL* keeps this same h2State alive across
+	// connections, seeing a preface again means a NEW connection has begun. If
+	// the conn has already carried H2 traffic, roll the shared witness namespace
+	// (bump epoch + regenerate bidiID) so this connection's stream 1/3/5... do
+	// not collide with the previous connection's on witness ID. Then reset our
+	// per-connection decode state (fresh HPACK context — the peer's dynamic
+	// table also resets per connection — and empty stream map).
+	if isH2ClientPreface(s.pending) {
+		if s.conn.h2Seen {
+			s.conn.h2Epoch++
+			s.conn.bidiID = akinet.TCPBidiID(uuid.New())
+		}
+		s.conn.h2Seen = true
+		s.epoch = s.conn.h2Epoch
+		s.resetForNewConnection()
 		s.pending = s.pending[len(H2Preface):]
+	}
+
+	// Peer direction (the one that does NOT carry the client preface, e.g. the
+	// server's SETTINGS side) picks up a connection roll lazily: when it sees
+	// the shared epoch has advanced past the one it last reset at, it resets its
+	// own per-connection decode state so it decodes the new connection under the
+	// new (regenerated) bidiID and a fresh HPACK context.
+	if s.epoch != s.conn.h2Epoch {
+		s.epoch = s.conn.h2Epoch
+		s.resetForNewConnection()
 	}
 
 	var out []akinet.ParsedNetworkTraffic
@@ -347,13 +424,26 @@ func (s *h2State) handleContinuation(flags uint8, streamID uint32, payload []byt
 }
 
 func (s *h2State) finalizeHeaderBlock(now time.Time, ifaceTag string) (akinet.ParsedNetworkTraffic, bool) {
+	// Once this connection's HPACK context has proven desynced, do not decode
+	// further HEADERS: the dynamic table is unreliable, so a "successful" decode
+	// could still yield wrong values. Consume the block and emit nothing. Frame
+	// parsing (which is length-prefixed and independent of HPACK) continues
+	// unaffected, so we stay in sync at the frame level.
+	if s.hpackDesynced {
+		s.headerBlock = s.headerBlock[:0]
+		return akinet.ParsedNetworkTraffic{}, false
+	}
+
 	fields, err := s.hpack.DecodeFull(s.headerBlock)
 	s.headerBlock = s.headerBlock[:0]
 	if err != nil {
-		// Likely mid-connection attach: the encoder's HPACK dynamic table
-		// state was built across HEADERS frames we never observed.
-		// Counter is exposed via HPACKErrors() so telemetry can surface it.
+		// Mid-connection attach: the encoder's HPACK dynamic table was built
+		// across HEADERS frames we never observed, so it has irrecoverably
+		// diverged from ours. Latch desync so we stop trusting this connection
+		// (see hpackDesynced). Counter is exposed via HPACKErrors() for
+		// telemetry.
 		s.hpackErrors++
+		s.hpackDesynced = true
 		return akinet.ParsedNetworkTraffic{}, false
 	}
 
@@ -498,7 +588,7 @@ func (s *h2State) emitStream(streamID uint32, now time.Time, ifaceTag string) (a
 			}
 		}
 		pnt.Content = akinet.HTTPRequest{
-			StreamID:   uuid.UUID(s.bidiID),
+			StreamID:   uuid.UUID(s.bidiID()),
 			Seq:        int(streamID),
 			Method:     st.method,
 			ProtoMajor: 2,
@@ -512,7 +602,7 @@ func (s *h2State) emitStream(streamID uint32, now time.Time, ifaceTag string) (a
 	}
 	if st.status != 0 {
 		pnt.Content = akinet.HTTPResponse{
-			StreamID:   uuid.UUID(s.bidiID),
+			StreamID:   uuid.UUID(s.bidiID()),
 			Seq:        int(streamID),
 			StatusCode: st.status,
 			ProtoMajor: 2,
@@ -543,5 +633,3 @@ func isPseudoHeader(name string) bool {
 	return len(name) > 0 && name[0] == ':'
 }
 
-// silence unused-import warnings when only some types are referenced.
-var _ = fmt.Sprintf

--- a/ebpf/events/http2_test.go
+++ b/ebpf/events/http2_test.go
@@ -64,7 +64,7 @@ func buildDataFrame(streamID uint32, endStream bool, body []byte) []byte {
 
 // TestH2_RequestNoBody — HEADERS with END_STREAM emits an HTTPRequest.
 func TestH2_RequestNoBody(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/users/42"},
@@ -96,7 +96,7 @@ func TestH2_RequestNoBody(t *testing.T) {
 
 // TestH2_RequestWithBody — HEADERS + DATA(END_STREAM) → HTTPRequest with body.
 func TestH2_RequestWithBody(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	headers := buildHeadersFrame(t, 3, false, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},
 		{Name: ":path", Value: "/echo"},
@@ -120,7 +120,7 @@ func TestH2_RequestWithBody(t *testing.T) {
 
 // TestH2_Response — :status pseudo-header yields an HTTPResponse.
 func TestH2_Response(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":status", Value: "204"},
 		{Name: "content-length", Value: "0"},
@@ -140,7 +140,7 @@ func TestH2_Response(t *testing.T) {
 
 // TestH2_Preface — preface is stripped before frame parsing.
 func TestH2_Preface(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/"},
@@ -154,7 +154,7 @@ func TestH2_Preface(t *testing.T) {
 
 // TestH2_MultipleStreams — interleaved frames on two streams produce two PNTs.
 func TestH2_MultipleStreams(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	h1 := buildHeadersFrame(t, 1, false, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/a"},
@@ -189,7 +189,7 @@ func TestH2_MultipleStreams(t *testing.T) {
 
 // TestH2_ChunkedDelivery — bytes split across multiple feed calls reassemble.
 func TestH2_ChunkedDelivery(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	frame := buildHeadersFrame(t, 1, true, []hpack.HeaderField{
 		{Name: ":method", Value: "GET"},
 		{Name: ":path", Value: "/chunked"},
@@ -259,7 +259,7 @@ func TestIsHTTP2Frame(t *testing.T) {
 // Host header is present (common for gRPC over HTTP/2), the emitted URL must
 // not be "https:///path".
 func TestH2_AuthorityFromHostHeader(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 	frame := buildHeadersFrame(t, 5, true, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},
 		{Name: ":path", Value: "/phase5c2.Greeter/SayHello"},
@@ -284,7 +284,7 @@ func TestH2_AuthorityFromHostHeader(t *testing.T) {
 // a length-prefixed message inside DATA should be decoded and the message
 // body should equal the protobuf payload (framing stripped).
 func TestH2_GRPCFraming(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 
 	// Build a gRPC request: HEADERS with :method=POST, :path=/svc/Method,
 	// content-type: application/grpc, followed by a DATA frame whose
@@ -326,7 +326,7 @@ func TestH2_GRPCFraming(t *testing.T) {
 // TestH2_GRPCFramingSplit: a gRPC message that arrives split across two
 // DATA frames must be reassembled (framing reassembly).
 func TestH2_GRPCFramingSplit(t *testing.T) {
-	s := newH2State(akinet.TCPBidiID(uuid.New()))
+	s := newH2State(&tlsConnState{bidiID: akinet.TCPBidiID(uuid.New())})
 
 	headers := buildHeadersFrame(t, 3, false, []hpack.HeaderField{
 		{Name: ":method", Value: "POST"},


### PR DESCRIPTION
An H2 witness ID is (StreamID=bidiID, Seq=streamID). bidiID is keyed by (PID, SSL*) and gotls reuses the same SSL* pointer across successive H2 connections while stream IDs restart at 1, so every reused connection re-emitted stream 1/3/5... under the same bidiID, colliding witness IDs and collapsing endpoints/counts in the UI. Detect each connection's client preface inside h2State.feed() (the reused flowState/h2State is not recreated between connections): bump a per-conn epoch and regenerate the shared bidiID so each connection gets its own witness namespace, and reset the per-connection HPACK decoder + stream map (both were wrongly persisting across connections). Both directions read the bidiID live and reset on epoch change, so request/response still pair. Also stop trusting a connection's HPACK context once decoding fails: a mid-connection attach leaves the dynamic table desynced, which can decode without error yet yield wrong header values. Latch the failure per direction and drop further HEADERS on that connection rather than emit possibly-corrupt witnesses; a connection roll clears the latch.