### PR TITLE
[AC-1165] Main container selection in discovery mode

### DIFF
--- a/cmd/internal/kube/daemonset/kube_events_worker.go
+++ b/cmd/internal/kube/daemonset/kube_events_worker.go
@@ -262,10 +262,11 @@ func (d *Daemonset) inspectPodForEnvVars(pod coreV1.Pod, podArgs *PodArgs) error
 	// flow for that pod instead of auto-discovery's RegisterDiscoveredService.
 	// Pods without explicit IDs continue to use auto-discovery unchanged.
 	if d.DiscoveryMode {
-		// Pick the first running container for network namespace capture.
-		mainUUID := ""
-		var mainConfig containerConfig
-		if len(containerUUIDs) > 0 {
+		// Prefer the container with explicit workspace/project IDs (hybrid mode).
+		// Do not use containerUUIDs[0]: sidecars like istio-proxy are often first
+		// and lack POSTMAN_INSIGHTS_* env vars on the application container.
+		mainUUID, mainConfig, _ := selectMainContainer(containerConfigMap)
+		if mainUUID == "" && len(containerUUIDs) > 0 {
 			mainUUID = containerUUIDs[0]
 			if cfg, ok := containerConfigMap[mainUUID]; ok {
 				mainConfig = cfg

--- a/cmd/internal/kube/daemonset/kube_events_worker_test.go
+++ b/cmd/internal/kube/daemonset/kube_events_worker_test.go
@@ -160,6 +160,30 @@ func testPod(name, namespace string) coreV1.Pod {
 	}
 }
 
+func TestSelectMainContainer_PrefersWorkspaceContainerOverSidecar(t *testing.T) {
+	validUUID := "12345678-1234-1234-1234-123456789abc"
+	validSystemEnv := "abcdefab-abcd-abcd-abcd-abcdefabcdef"
+
+	sidecarUUID := "istio-proxy-uuid"
+	appUUID := "app-container-uuid"
+
+	containerConfigMap := map[string]containerConfig{
+		sidecarUUID: {requiredContainerConfig: requiredContainerConfig{}},
+		appUUID: {
+			requiredContainerConfig: requiredContainerConfig{
+				workspaceID: validUUID,
+				systemEnv:   validSystemEnv,
+			},
+		},
+	}
+
+	uuid, config, result := selectMainContainer(containerConfigMap)
+	assert.Equal(t, appUUID, uuid)
+	assert.Equal(t, validUUID, config.requiredContainerConfig.workspaceID)
+	assert.Equal(t, validSystemEnv, config.requiredContainerConfig.systemEnv)
+	assert.Equal(t, 2, result.ValidAttrCount)
+}
+
 func TestApplyDiscoveryModeConfig_NoExplicitIDs(t *testing.T) {
 	d := &Daemonset{
 		DiscoveryMode:       true,


### PR DESCRIPTION
This pull request improves how the main application container is selected in discovery mode, especially in pods with sidecars like Istio. It now prefers containers with explicit workspace or project IDs, making the selection more accurate and robust. Additionally, a targeted unit test is added to verify this behavior.

**Container selection logic improvements:**

* Updated `inspectPodForEnvVars` in `kube_events_worker.go` to use `selectMainContainer`, prioritizing containers with explicit workspace/project IDs over simply picking the first container. This avoids mistakenly selecting sidecars (e.g., `istio-proxy`) as the main container.

**Testing enhancements:**

* Added `TestSelectMainContainer_PrefersWorkspaceContainerOverSidecar` in `kube_events_worker_test.go` to ensure that containers with explicit workspace IDs are correctly preferred over sidecars during main container selection.